### PR TITLE
Fixed Component: DsInputBase SSR nth-child warning fixed

### DIFF
--- a/src/Components/DsInputBase/DsInputBase.Overrides.ts
+++ b/src/Components/DsInputBase/DsInputBase.Overrides.ts
@@ -119,10 +119,9 @@ export const DsInputBaseOverrides = {
           padding: 'var(--ds-spacing-deepFreeze)',
           height: 'auto'
         },
-        // The warning for SSR let it be
-        '> :nth-child(even)': {
+        '> :first-of-type + *': {
           marginLeft: 'var(--ds-spacing-quickFreeze)'
-        }
+        },
       } as CSSInterpolation,
       input: {
         padding: 'var(--ds-spacing-quickFreeze) var(--ds-spacing-zero)',


### PR DESCRIPTION
DSInputBase _nth-child(even)_ css property replaced with  _> :first-of-type + *_  to handle the SSR warning