### PR TITLE
Added Feature: DsProgressTracker header label disable and warning state

### DIFF
--- a/src/Components/DsProgressTracker/Components/DsProgressStepper.Component.tsx
+++ b/src/Components/DsProgressTracker/Components/DsProgressStepper.Component.tsx
@@ -17,9 +17,9 @@ export const DsProgressStepper: FC<DsProgressStepperProps> = inProps => {
     const { active, error, completed, icon } = stepProps
 
     const isWarning = typeof icon === 'string' && icon === 'warning'
-    const isError = typeof icon === 'string' && icon === 'error'
+    const isError = error || ( typeof icon === 'string' && icon === 'error')
 
-    if (error || isError) {
+    if (isError) {
       return (
         <DsRemixIcon
           className='ri-close-circle-fill'

--- a/src/Components/DsProgressTracker/Components/DsProgressStepper.Component.tsx
+++ b/src/Components/DsProgressTracker/Components/DsProgressStepper.Component.tsx
@@ -16,11 +16,23 @@ export const DsProgressStepper: FC<DsProgressStepperProps> = inProps => {
   const renderStepIcon = (stepProps: StepIconProps) => {
     const { active, error, completed, icon } = stepProps
 
-    if (error) {
+    const isWarning = typeof icon === 'string' && icon === 'warning'
+    const isError = typeof icon === 'string' && icon === 'error'
+
+    if (error || isError) {
       return (
         <DsRemixIcon
           className='ri-close-circle-fill'
           sx={{ color: 'var(--ds-colour-iconNegative)' }}
+        />
+      )
+    }
+
+    if (isWarning) {
+      return (
+        <DsRemixIcon
+          className='ri-error-warning-fill'
+          sx={{ color: 'var(--ds-colour-supportWarning)' }}
         />
       )
     }

--- a/src/Components/DsProgressTracker/Components/DsProgressTrackerHeader.Component.tsx
+++ b/src/Components/DsProgressTracker/Components/DsProgressTrackerHeader.Component.tsx
@@ -14,6 +14,8 @@ export const DsProgressTrackerHeader = (props: DsProgressTrackerProps) => {
     dense,
     onClick,
     StepperProps,
+    stepLabelVisible,
+    lastStepLabelText,
     ...wrapperProps
   } = props
 
@@ -33,7 +35,7 @@ export const DsProgressTrackerHeader = (props: DsProgressTrackerProps) => {
         variant='subheadingSemiboldDefault'
       >
         {isNextStepLastStep
-          ? 'Yay! you are almost done'
+          ? lastStepLabelText
           : `${nextStepLabelPrefix} ${nextStep.stepName}`}
       </DsTypography>
     )
@@ -61,7 +63,7 @@ export const DsProgressTrackerHeader = (props: DsProgressTrackerProps) => {
               {`STEP ${activeStep + 1} OF ${steps.length}`}
             </DsTypography>
             <DsStack direction='row' spacing='var(--ds-spacing-frostbite)'>
-              {haveNextStep && renderStepsLabel()}
+              {haveNextStep && stepLabelVisible && renderStepsLabel()}
               {props['ds-variant'] !== 'header' && (
                 <DsRemixIcon
                   fontSize='bitterCold'
@@ -111,7 +113,7 @@ export const DsProgressTrackerHeader = (props: DsProgressTrackerProps) => {
             >
               {currentStep.stepName}
             </DsTypography>
-            {haveNextStep && renderStepsLabel()}
+            {haveNextStep && stepLabelVisible && renderStepsLabel()}
           </DsStack>
         </DsStack>
       )}

--- a/src/Components/DsProgressTracker/DsProgressStepper.Types.ts
+++ b/src/Components/DsProgressTracker/DsProgressStepper.Types.ts
@@ -5,6 +5,11 @@ import { DsStepperProps } from '../DsStepper'
 export interface DsProgressStepperStepProps {
   stepName?: string
   error?: DsStepLabelProps['error']
+    /**
+   * Icon to display for the step. Can be a standard icon or special values:
+   * - 'warning': Shows a warning icon with warning color
+   * - 'error': Shows an error icon
+   */
   icon?: Exclude<DsStepLabelProps['icon'], string>
   | 'warning'
   | 'error'

--- a/src/Components/DsProgressTracker/DsProgressStepper.Types.ts
+++ b/src/Components/DsProgressTracker/DsProgressStepper.Types.ts
@@ -5,7 +5,9 @@ import { DsStepperProps } from '../DsStepper'
 export interface DsProgressStepperStepProps {
   stepName?: string
   error?: DsStepLabelProps['error']
-  icon?: DsStepLabelProps['icon']
+  icon?: Exclude<DsStepLabelProps['icon'], string>
+  | 'warning'
+  | 'error'
   optional?: DsStepLabelProps['optional']
   completed?: DsStepProps['completed']
   disabled?: DsStepProps['disabled']

--- a/src/Components/DsProgressTracker/DsProgressTracker.Types.ts
+++ b/src/Components/DsProgressTracker/DsProgressTracker.Types.ts
@@ -32,6 +32,14 @@ export interface DsProgressTrackerProps extends DsStackProps {
    * This prop can be used to provide a custom prefix string to the step label.
    */
   nextStepLabelPrefix?: React.ReactNode
+  /**
+   * This prop can be used to hide/show the lable on progress tarcker header.
+   */
+  stepLabelVisible?: boolean
+  /**
+   * This prop can be used to show custom lable text for last step.
+   */
+  lastStepLabelText?: string
 }
 
 export const DsProgressTrackerDefaultProps: DsProgressTrackerProps = {
@@ -40,8 +48,9 @@ export const DsProgressTrackerDefaultProps: DsProgressTrackerProps = {
   dense: false,
   steps: [],
   StepperProps: { orientation: 'vertical' },
-  sx: {},
-  nextStepLabelPrefix: 'Next Step : '
+  nextStepLabelPrefix: 'Next Step : ',
+  stepLabelVisible: true,
+  lastStepLabelText: 'Yay! you are almost done'
 }
 
 export interface DsProgressTrackerState {

--- a/src/Components/DsProgressTracker/DsProgressTracker.Types.ts
+++ b/src/Components/DsProgressTracker/DsProgressTracker.Types.ts
@@ -33,11 +33,11 @@ export interface DsProgressTrackerProps extends DsStackProps {
    */
   nextStepLabelPrefix?: React.ReactNode
   /**
-   * This prop can be used to hide/show the lable on progress tarcker header.
+   * This prop can be used to hide/show the label on progress tacker header.
    */
   stepLabelVisible?: boolean
   /**
-   * This prop can be used to show custom lable text for last step.
+   * This prop can be used to show custom label text for last step.
    */
   lastStepLabelText?: string
 }


### PR DESCRIPTION
## 📝 Summary

1. Added a warning state to tghe progressTracker stepper component.
2. Added support to show/hide label text on header with a prop to customize the end step label

## 📌 Related Issue
SUB-784

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [ ] Updated documentation/comments where needed
- [x] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [x] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:

1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/rreact-design-system -> dist

## 📸 Screenshots / Videos (if applicable)

Custom last step header label
<img width="1018" alt="Screenshot 2025-06-30 at 4 31 28 PM" src="https://github.com/user-attachments/assets/49f73065-0c4f-43b3-9400-6e842b889436" />

Warning state fro stepper
<img width="1023" alt="Screenshot 2025-06-30 at 4 31 54 PM" src="https://github.com/user-attachments/assets/bfb4719a-953f-4fff-b4a9-0d6a038d0239" />

Hidden step label - 
<img width="1023" alt="Screenshot 2025-06-30 at 4 32 20 PM" src="https://github.com/user-attachments/assets/0aa8522a-cba1-4a7c-a69d-97914ea2e331" />




## 🧩 Notes
Any extra context, edge cases, or known limitations.