### PR TITLE
Added Feature: DsFileUploader compreseed variant and controlled varia…

### DIFF
--- a/src/Components/DsFileUploader/DsFileUploader.Component.tsx
+++ b/src/Components/DsFileUploader/DsFileUploader.Component.tsx
@@ -1,307 +1,259 @@
-import React, { DragEvent, FC, useRef, useState } from 'react'
+import type React from 'react'
+import type { DragEventHandler } from 'react'
+import { useEffect, useState } from 'react'
 
-import { DsBox } from '../DsBox'
-import { DsButton } from '../DsButton'
-import { DsIconButton } from '../DsIconButton'
-import { DsInput } from '../DsInput'
-import { DsRemixIcon } from '../DsRemixIcon'
-import { DsStack } from '../DsStack'
-import { DsTypography } from '../DsTypography'
-
-import {
-  DsFileUploaderDefaultProps,
-  DsFileUploaderDefaultState,
-  DsFileUploaderProps,
-  DsFileUploaderState
+import type {
+  IDsFileUploaderProps,
+  TContentType,
+  TErrorFile,
+  TErrorValue,
+  TFile,
+  TMultiple,
+  TValue
 } from './DsFileUploader.Types'
+import { DsFileUploaderDefaultProps } from './DsFileUploader.Types'
+import FileUploaderFiles from './FileUploaderFiles'
+import { getDefaultValue, getValidProcessedFile, mergeProps } from './helpers'
+import { DsFileUploaderDropZone } from './Slots/DsFileUploaderDropZone'
+import { DsStack } from '../DsStack'
+import { DsInputLabel } from '../DsInputLabel'
 
-export const DsFileUploader: FC<
-  DsFileUploaderProps
-> = (inProps) => {
-  const props = {  ...DsFileUploaderDefaultProps, ...inProps}
-  const inputRef = useRef<HTMLInputElement>()
-  const [files, setFiles] = useState<DsFileUploaderState['files']>([])
+export const DsFileUploader = <
+  Multiple extends TMultiple,
+  ContentType extends TContentType
+>(
+  inProps: IDsFileUploaderProps<Multiple, ContentType>
+) => {
+  // Merge user props with default props, handling nested slots and slotProps gracefully
+  const props = mergeProps<IDsFileUploaderProps<Multiple, ContentType>>(
+    inProps,
+    DsFileUploaderDefaultProps as IDsFileUploaderProps<Multiple, ContentType>
+  )
+  const defaultValue = getDefaultValue<Multiple, ContentType>(props)
 
-  const humaniseSize = (bytes: number, decimals: number = 2) => {
-    if (!+bytes) return '0 Bytes'
+  const [files, setFiles] = useState<TValue<Multiple, ContentType> | null>(
+    defaultValue
+  )
 
-    const k = 1024
-    const dm = decimals < 0 ? 0 : decimals
-    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+  const {
+    InputLabelProps,
+    name,
+    value,
+    uploadedValue,
+    accept = '*',
+    minSize,
+    maxSize,
+    onChange,
+    onError,
+    onDelete,
+    onPreview,
+    onDownload,
+    multiple,
+    slotProps = {},
+    variant,
+    contentType,
+    canDeleteFile,
+    slots = {}
+  } = props
 
-    const i = Math.floor(Math.log(bytes) / Math.log(k))
+  // Effective file type accept string — pulled from DropZone slotProps or `accept`
+  const allowedFiles =
+    (slotProps?.DropZone && slotProps?.DropZone.InputProps?.accept) || accept
 
-    return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`
-  }
-
-  const getFileIconClass = (mimeType: string) => {
-    if (mimeType.includes('image/')) {
-      return 'ri-image-2-line'
+  useEffect(() => {
+    if (value !== undefined) {
+      setFiles(value)
     }
+  }, [value])
 
-    if (mimeType.includes('video/')) {
-      return 'ri-video-line'
+  // Handles selected or dropped files after validation
+  const handleFiles = (processedFiles: {
+    valid: TValue<Multiple, ContentType> | null
+    invalid: TErrorValue<Multiple, ContentType>
+  }) => {
+    const { valid, invalid } = processedFiles
+
+    // If not controlled, update internal state
+    if (value === undefined) {
+      setFiles(valid)
     }
-
-    return 'ri-file-list-2-line'
-  }
-
-  const handleOnClick = (event: React.MouseEvent<HTMLElement>) => {
-    inputRef?.current?.click()
-  }
-
-  const handleRemoveFile = (index: number) => () => {
-    const { onChange, name } = props
-    const tempFiles = [...files]
-    tempFiles.splice(index, 1)
-     setFiles(tempFiles)
 
     if (onChange && typeof onChange === 'function') {
-      onChange(name, [...tempFiles]);
+      onChange(name, valid as TValue<Multiple, ContentType>)
+    }
+
+    if (invalid !== null) {
+      if (invalid && onError && typeof onError === 'function') {
+        onError(name, invalid)
+      }
     }
   }
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const { onChange, name } = props
-    const stateFiles = files
+  // Triggered when a user selects files via the input element
+  const handleFileSelect = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
     const { target } = event
     const { files: selectedFiles } = target
+
+    if (!multiple && uploadedValue) {
+      if (onDelete && typeof onDelete === 'function') {
+        onDelete(name, uploadedValue as TFile<ContentType>)
+      }
+    }
+
     if (selectedFiles) {
-      const newFiles = [...stateFiles, ...selectedFiles]
-      setFiles(newFiles)
-
-      if (onChange && typeof onChange === 'function') {
-        onChange(name, newFiles)
-      }
-    }
-  }
-
-  const handleDrop = (event: DragEvent) => {
-    // Prevent default behavior (Prevent file from being opened)
-    event.preventDefault()
-
-    const { InputProps = {}, onChange, name } = props
-    const { accept, multiple } = InputProps
-
-    if (!event.dataTransfer) {
-      return
-    }
-
-    let files: File[] = []
-    const items = event.dataTransfer.items
-      ? [...event.dataTransfer.items]
-      : [...event.dataTransfer.files]
-
-    items.forEach(item => {
-      let file
-
-      if (!multiple && files.length) {
-        return
-      }
-
-      if (item instanceof DataTransferItem) {
-        if (item.kind === 'file') {
-          file = item.getAsFile()
-        }
-      } else {
-        file = item
-      }
-
-      if (!file) {
-        return
-      }
-
-      const { type } = file
-      const astrerikType = `${type.split('/')[0]}/*`
-
-      if (accept.includes(type) || accept.includes(astrerikType)) {
-        files.push(file)
-      }
-    })
-
-    const stateFiles = files
-    const newFiles = multiple
-      ? [...stateFiles, ...files]
-      : (files[0] && [files[0]]) || (stateFiles[0] && [stateFiles[0]]) || []
-
-   setFiles(newFiles)
-
-    if (onChange && typeof onChange === 'function') {
-      onChange(name, newFiles)
-    }
-  }
-
-  const handleDragOverHandler = (event: DragEvent) => {
-    // Prevent default behavior (Prevent file from being opened)
-    event.preventDefault()
-  }
-
-  const renderFiles = () => {
-
-    if (!files.length) {
-      return false
-    }
-
-    const Files: React.ReactElement[] = []
-
-    for (let index = 0; index < files.length; index++) {
-      const file: File = files[index]
-
-      Files.push(
-        <DsStack
-          key={`${file.name}-${index}`}
-          direction="row"
-          spacing="var(--ds-spacing-bitterCold)"
-          alignItems="center"
-          sx={{
-            p: 'var(--ds-spacing-bitterCold)',
-            borderRadius: 'var(--ds-radius-glacial)',
-            borderWidth: '1px',
-            borderStyle: 'solid',
-            borderColor: 'var(--ds-colour-strokeDefault)',
-            backgroundColor: 'var(--ds-colour-surfacePrimary)',
-            cursor: 'pointer',
-            '&:hover': {
-              borderColor: 'var(--ds-colour-strokeSecondarySelected)',
-              backgroundColor: 'var(--ds-colour-stateSelectedSecondaryHover)'
-            }
-          }}
-        >
-          <DsRemixIcon
-            sx={{
-              p: 'var(--ds-spacing-quickFreeze)',
-              borderRadius: 'var(--ds-radius-quickFreeze)',
-              backgroundColor: 'var(--ds-colour-neutral2)',
-              color: 'var(--ds-colour-actionTertiary)'
-            }}
-            className={getFileIconClass(file.type)}
-          />
-          <DsBox
-            sx={{
-              display: 'flex',
-              flexGrow: 1,
-              minWidth: 0,
-              flexDirection: 'column'
-            }}
-          >
-            <DsTypography
-              component="div"
-              variant="subheadingSemiboldDefault"
-              noWrap
-            >
-              {file.name}
-            </DsTypography>
-            <DsTypography
-              component="div"
-              variant="bodyRegularSmall"
-              noWrap
-              sx={{
-                color: 'var(--ds-colour-typoTertiary)'
-              }}
-            >
-              {humaniseSize(file.size)}
-            </DsTypography>
-          </DsBox>
-          <DsIconButton onClick={handleRemoveFile(index)}>
-            <DsRemixIcon className="ri-close-line" />
-          </DsIconButton>
-        </DsStack>
+      const processedFiles = await getValidProcessedFile<Multiple, ContentType>(
+        selectedFiles,
+        files ?? null,
+        accept,
+        minSize,
+        maxSize,
+        contentType
       )
-    }
 
-    return (
-      <DsStack
-        sx={{
-          mt: 'var(--ds-spacing-warm)',
-          width: '100%'
-        }}
-        spacing="var(--ds-spacing-glacial)"
-        direction="column"
-      >
-        {Files}
-      </DsStack>
-    )
+      handleFiles(processedFiles)
+    }
   }
 
-    const {
-      IconProps,
-      titleButtonText,
-      TitleButtonProps,
-      descriptionTypograpghyText,
-      DescriptionTypograpghyProps,
-      InputProps
-    } = props
-    return (
-      <>
-        <DsStack
-          sx={{
-            width: '100%',
-            position: 'relative',
-            p: 'var(--ds-spacing-bitterCold)',
-            borderRadius: 'var(--ds-radius-glacial)',
-            borderWidth: '1px',
-            borderStyle: 'dashed',
-            borderColor: 'var(--ds-colour-strokeDefault)',
-            backgroundColor: 'var(--ds-colour-surfacePrimary)',
-            cursor: 'pointer',
-            '&:hover': {
-              borderColor: 'var(--ds-colour-strokeSecondarySelected)',
-              backgroundColor: 'var(--ds-colour-stateSelectedSecondaryHover)'
-            }
-          }}
-          direction="column"
-          spacing="var(--ds-spacing-glacial)"
+  // Triggered when a user drops files into the drop zone
+  const handleDropFile: DragEventHandler<
+    HTMLInputElement | HTMLTextAreaElement
+  > = async event => {
+    event.preventDefault()
+    const { dataTransfer } = event
+
+    if (dataTransfer) {
+      const { files: selectedFiles } = dataTransfer
+
+      if (!multiple && uploadedValue) {
+        if (onDelete && typeof onDelete === 'function') {
+          onDelete(name, uploadedValue as TFile<ContentType>)
+        }
+      }
+
+      if (files) {
+        const processedFiles = await getValidProcessedFile<
+          Multiple,
+          ContentType
+        >(selectedFiles, files ?? null, accept, minSize, maxSize)
+        handleFiles(processedFiles)
+      }
+    }
+  }
+
+  // Prevent default behavior to allow dropping
+  const handleDragOverHandler: DragEventHandler<
+    HTMLInputElement | HTMLTextAreaElement
+  > = event => {
+    event.preventDefault()
+  }
+
+  // Triggered when a user removes a file
+  const handleRemoveFile = async (name: string, file: TFile<TContentType>) => {
+    // Async handler for delete operations
+    if (canDeleteFile && typeof canDeleteFile === 'function') {
+      const canDelete = await canDeleteFile(name, file)
+      if (!canDelete) return
+    }
+
+    if (onDelete && typeof onDelete === 'function') {
+      onDelete(name, file)
+    }
+
+    // Update internal state after deletion
+    if (Array.isArray(files)) {
+      const newFiles = files.filter(f => f !== file) as TValue<
+        Multiple,
+        ContentType
+      >
+      const valid = newFiles
+      const invalid: TErrorFile<ContentType>[] = []
+
+      handleFiles({
+        valid: valid,
+        invalid: invalid as TErrorValue<Multiple, ContentType>
+      })
+    } else {
+      handleFiles({
+        valid: null,
+        invalid: null as TErrorValue<Multiple, ContentType>
+      })
+    }
+  }
+
+  // Preview handler
+  const handlePreviewFileAction = (name: string, file: TFile<TContentType>) => {
+    if (onPreview && typeof onPreview === 'function') {
+      onPreview(name, file)
+    }
+  }
+
+  // Download handler
+  const handleDownloadFileAction = (
+    name: string,
+    file: TFile<TContentType>
+  ) => {
+    if (onDownload && typeof onDownload === 'function') {
+      onDownload(name, file)
+    }
+  }
+
+  // Visibility conditions for selected and uploaded sections
+  const isSelectedSegmentVisible = multiple
+    ? Array.isArray(files) && files.length > 0
+    : files
+  const isUploadedSegmentVisible = multiple
+    ? Array.isArray(uploadedValue) && uploadedValue.length > 0
+    : uploadedValue
+
+  const { SelectedItemSegment, UploadedItemSegment } = slots
+
+  return (
+    <DsStack
+      direction='column'
+      sx={{
+        gap: 'var(--ds-spacing-bitterCold)',
+        width: '100%',
+        p: 'var(--ds-spacing-bitterCold)'
+      }}
+    >
+      <DsInputLabel
+        sx={{ mb: 'var(--ds-spacing-zero)', ...InputLabelProps?.sx }}
+        {...InputLabelProps}
+      />
+      <DsFileUploaderDropZone
+        variant={variant}
+        {...slotProps?.DropZone}
+        InputProps={{
+          accept: allowedFiles || accept,
+          multiple: multiple,
+          onChange: handleFileSelect,
+          onDrop: handleDropFile,
+          onDragOver: handleDragOverHandler,
+          ...slotProps?.DropZone?.InputProps
+        }}
+      />
+      {isSelectedSegmentVisible && SelectedItemSegment && (
+        <SelectedItemSegment
+          onPreview={handlePreviewFileAction}
+          onDownload={handleDownloadFileAction}
+          onDelete={handleRemoveFile}
+          {...slotProps?.SelectedItemSegment}
         >
-          <DsRemixIcon
-            className="ri-upload-cloud-2-line"
-            color="secondary"
-            {...IconProps}
-          />
-          <DsButton variant="text" color="secondary" {...TitleButtonProps}>
-            {titleButtonText}
-          </DsButton>
-          <DsTypography
-            variant="bodyRegularSmall"
-            align="center"
-            {...DescriptionTypograpghyProps}
-            sx={{
-              color: 'var(--ds-colour-typoTertiary)',
-              ...DescriptionTypograpghyProps?.sx
-            }}
-          >
-            {descriptionTypograpghyText}
-          </DsTypography>
-          <DsInput
-            type="file"
-            sx={{
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              height: '100%',
-              width: '100%',
-              opacity: 0,
-              cursor: 'pointer',
-              margin: 'var(--ds-spacing-zero) !important'
-            }}
-            onChange={handleChange}
-            onDrop={handleDrop}
-            onDragOver={handleDragOverHandler}
-            disableUnderline
-            inputProps={{
-              title: titleButtonText as string,
-              ref: inputRef,
-              value: '',
-              ...InputProps,
-              style: {
-                height: '100%',
-                width: '100%',
-                cursor: 'pointer',
-                ...InputProps?.style
-              }
-            }}
-          />
-        </DsStack>
-        {renderFiles()}
-      </>
-    )
+          <FileUploaderFiles slots={slots} files={files || undefined} />
+        </SelectedItemSegment>
+      )}
+      {isUploadedSegmentVisible && UploadedItemSegment && (
+        <UploadedItemSegment
+          onPreview={handlePreviewFileAction}
+          onDownload={handleDownloadFileAction}
+          onDelete={handleRemoveFile}
+          {...slotProps?.UploadedItemSegment}
+        >
+          <FileUploaderFiles slots={slots} files={uploadedValue || undefined} />
+        </UploadedItemSegment>
+      )}
+    </DsStack>
+  )
 }

--- a/src/Components/DsFileUploader/DsFileUploader.Component.tsx
+++ b/src/Components/DsFileUploader/DsFileUploader.Component.tsx
@@ -241,7 +241,11 @@ export const DsFileUploader = <
           onDelete={handleRemoveFile}
           {...slotProps?.SelectedItemSegment}
         >
-          <FileUploaderFiles slots={slots} files={files || undefined} />
+          <FileUploaderFiles
+            slots={slots}
+            slotProps={slotProps}
+            files={files || undefined}
+          />
         </SelectedItemSegment>
       )}
       {isUploadedSegmentVisible && UploadedItemSegment && (
@@ -251,7 +255,11 @@ export const DsFileUploader = <
           onDelete={handleRemoveFile}
           {...slotProps?.UploadedItemSegment}
         >
-          <FileUploaderFiles slots={slots} files={uploadedValue || undefined} />
+          <FileUploaderFiles
+            slots={slots}
+            slotProps={slotProps}
+            files={uploadedValue || undefined}
+          />
         </UploadedItemSegment>
       )}
     </DsStack>

--- a/src/Components/DsFileUploader/DsFileUploader.Overrides.tsx
+++ b/src/Components/DsFileUploader/DsFileUploader.Overrides.tsx
@@ -1,1 +1,7 @@
-export const DsFileUploaderOverrides = {}
+import { DsFileUploaderDefaultProps } from './DsFileUploader.Types'
+
+export const DsFileUploaderOverrides = {
+  DsFileUploader: {
+    defaultProps: DsFileUploaderDefaultProps
+  }
+}

--- a/src/Components/DsFileUploader/DsFileUploader.Types.tsx
+++ b/src/Components/DsFileUploader/DsFileUploader.Types.tsx
@@ -95,7 +95,7 @@ export interface IDsFileUploaderProps<
    * @param {TVariant} variant The variant of file uploader component.
    * @default 'FULL'
    */
-  variant: TVariant
+  variant?: TVariant
   /**
    * The `input` value. Value should be array of `TFile<TContentType>` type objects. If you have multiple false then value would be null
    * @default []
@@ -350,6 +350,7 @@ export const DsFileUploaderDefaultProps: IDsFileUploaderProps<
   value: undefined,
   accept: '*',
   variant: 'FULL',
+  multiple: true,
   slots: {
     DropZone: DsFileUploaderDropZone,
     UploadedItemSegment: DsFileUploaderUploadedFilesSegment,

--- a/src/Components/DsFileUploader/DsFileUploader.Types.tsx
+++ b/src/Components/DsFileUploader/DsFileUploader.Types.tsx
@@ -278,6 +278,10 @@ export interface IDsFileUploaderItemSegmentProps extends DsStackProps {
    slots prop is used to provide custom slots components to the file uploader
    */
   slots?: IDsFileUploaderProps['slots']
+  /**
+   slotPros used to provide custom props to the individual slots of the file uploader
+   */
+  slotProps?: IDsFileUploaderProps['slotProps']
 }
 
 export interface IDsFileUploaderActionButtonProps extends DsIconButtonProps {

--- a/src/Components/DsFileUploader/DsFileUploader.Types.tsx
+++ b/src/Components/DsFileUploader/DsFileUploader.Types.tsx
@@ -1,31 +1,378 @@
-import { DsButtonProps } from '../DsButton'
-import { DsInputProps } from '../DsInput'
+import type { ElementType } from 'react'
+import { DsInputLabelProps } from '../DsInputLabel'
 import { DsRemixIconProps } from '../DsRemixIcon'
-import { DsTypographyProps } from '../DsTypography'
+import { DsStackProps } from '../DsStack'
+import { DsInputProps } from '../DsInput'
+import { DsIconButtonProps } from '../DsIconButton'
+import { DsFileUploaderActionButton } from './Slots/DsFileUploaderActionButton.Component'
+import { DsFileUploaderDropZone } from './Slots/DsFileUploaderDropZone'
+import { DsFileUploaderSelectedFilesSegment } from './Slots/DsFileUploaderSelectedFilesSegment'
+import { DsFileUploaderUploadedFilesSegment } from './Slots/DsFileUploaderUploadedFilesSegment'
 
-export interface DsFileUploaderProps {
+export enum CONTENT_TYPE {
+  FILE = 'FILE',
+  BASE64 = 'BASE64'
+}
+
+export enum VARIANT {
+  FULL = 'FULL',
+  COMPRESSED = 'COMPRESSED'
+}
+
+export type TMultiple = boolean | undefined
+export type TContentType = keyof typeof CONTENT_TYPE
+export type TVariant = keyof typeof VARIANT
+export type TFileType<TContentType> = TContentType extends 'FILE'
+  ? File
+  : string
+
+export type TFile<TContentType> = {
+  /**
+   * Name of the file selected or dropped.
+   */
   name: string
-  onChange: (name: string, files: File[]) => void
+  /**
+   * mime-type of the file selected or dropped.
+   */
+  type: string
+  /**
+   * size in bytes of the file selected or dropped.
+   */
+  size: number
+  /**
+   * content of the file selected or dropped.
+   */
+  content: TFileType<TContentType>
+  /**
+   * Unique Identifier for the file.
+   */
+  id?: string
+  /**
+   * Extra content required to be displayed with the file name and size
+   */
+  subText?: string
+}
+
+export type TValue<Multiple, TContentType> = Multiple extends false
+  ? TFile<TContentType> | null | undefined
+  : TFile<TContentType>[] | undefined
+
+export type TProcessFile<TMultiple, TContentType> = {
+  valid: TValue<TMultiple, TContentType>
+  invalid: TErrorValue<TMultiple, TContentType>
+}
+
+export enum ERROR_CODES {
+  INVALID_FILE_TYPE = 'INVALID_FILE_TYPE',
+  MAX_FILE_SIZE_EXCEEDED = 'MAX_FILE_SIZE_EXCEEDED',
+  FILE_SIZE_BELOW_MIN = 'FILE_SIZE_BELOW_MIN'
+}
+
+export type TErrorCodes = keyof typeof ERROR_CODES
+
+export type TErrorFile<CONTENT_TYPE> = {
+  file: TFile<CONTENT_TYPE>
+  errorCode: TErrorCodes
+}
+
+export type TErrorValue<Multiple, CONTENT_TYPE> = Multiple extends false
+  ? TErrorFile<CONTENT_TYPE> | null
+  : TErrorFile<CONTENT_TYPE>[]
+
+export interface IDsFileUploaderProps<
+  Multiple extends TMultiple = true,
+  ContentType extends TContentType = 'FILE'
+> {
+  InputLabelProps?: Omit<
+    DsInputLabelProps,
+    'ref' | 'error' | 'success' | 'htmlFor' | 'disabled'
+  >
+  /**
+   * Name attribute of the input element.
+   */
+  name: string
+  /**
+   * @param {TVariant} variant The variant of file uploader component.
+   * @default 'FULL'
+   */
+  variant: TVariant
+  /**
+   * The `input` value. Value should be array of `TFile<TContentType>` type objects. If you have multiple false then value would be null
+   * @default []
+   */
+  value?: TValue<Multiple, ContentType> | null
+  /**
+   * The `input` uploadedValue. uploadedValue should be array of `TFile<TContentType>` type objects of your previously uploaded files. If you have multiple false then uploadedValue would be null
+   * @default []
+   */
+  uploadedValue?: TValue<Multiple, ContentType>
+  /**
+   * validate the minimum file size (in bytes).
+   *
+   * If file size is below the provided value then file will be passed back in `onError` callback.
+   */
+  minSize?: number
+  /**
+   * The `content` type in the file object returned in callbacks for newly selected files.
+   * @default 'FILE'
+   */
+  contentType?: TContentType
+  /**
+   * validate the maximum file size (in bytes).
+   *
+   * If file size exceeds the provided value then file will be passed back in `onError` callback.
+   */
+  maxSize?: number
+  /**
+   * The `accept` attribute of the input element.
+   *
+   * This will allow to restrict user to only upload specific type of files.
+   *
+   * If you want to allow only images then use `accept='image/*'` and so on.
+   *
+   * By default it will allow any file.
+   * @default '*'
+   */
+  accept?: string
+  /**
+   * The `multiple` attribute of the input element.
+   *
+   * If `false` then user can upload only single file.
+   * @default false
+   */
+  multiple?: Multiple
+  /**
+   * To override icon associated to each file type. Called in loop for all selected files
+   *
+   * @param {string} name The name provided to the component.
+   * @param {TFile<ContentType>} [file] This would be the valid `TFile<ContentType>` type objects selected with its content value depending on `contentType` props or as provided in value.
+   */
+  FileIconMapper?: (file: TFile<ContentType>) => DsRemixIconProps['className']
+  /**
+   * Callback fired when a invalid file is selected or dropped.
+   *
+   * @param {string} name The name provided to the component.
+   * @param { TErrorValue<Multiple, ContentType>} [files] This would be the valid `T_ERROR_FILE` type objects selected with its content as `FILE` type or as provided in value with the error code.
+   */
+
+  onError?: (name: string, files: TErrorValue<Multiple, ContentType>) => void
+  /**
+   * Callback fired when a file is selected or dropped.
+   *
+   * @param {string} name The name provided to the component.
+   * @param {TValue<Multiple, ContentType>} [files] This would be the valid `T_FILE_UPLOADER` type objects selected with its content value depending on `contentType` props or as provided in value.
+   */
+  onChange: (name: string, files: TValue<Multiple, ContentType>) => void
+  /**
+   * Callback fired when an existing file is removed.
+   *
+   * @param {string} name The name provided to the component.
+   * @param {TFile<ContentType>} [file] This would be the valid `TFile<ContentType>` type objects selected with its content value depending on `contentType` props or as provided in value.
+   */
+  onDelete?: (name: string, file: TFile<ContentType>) => void
+
+  /**
+   * This is a handler that user can use to pass boolean if delete operation is async/API driven.
+   *
+   * @param {string} name The name provided to the component.
+   * @param {TFile<ContentType>} [file] This would be the valid `TFile<ContentType>` type objects selected with its content value depending on `contentType` props or as provided in value.
+   */
+  canDeleteFile?: (name: string, file: TFile<ContentType>) => Promise<boolean>
+
+  /**
+   * Callback fired when an preview button is clicked for an existing file.
+   *
+   * @param {string} name The name provided to the component.
+   * @param {TFile<ContentType>} [file] This would be the valid `TFile<ContentType>` type objects selected with its content value depending on `contentType` props or as provided in value.
+   */
+  onPreview?: (name: string, file: TFile<ContentType>) => void
+  /**
+   * Callback fired when an download button is clicked for an existing file.
+   *
+   * @param {string} name The name provided to the component.
+   * @param {TFile<ContentType>} [file] This would be the valid `TFile<ContentType>` type objects selected with its content value depending on `contentType` props or as provided in value.
+   */
+  onDownload?: (name: string, file: TFile<ContentType>) => void
+  /**
+   slots prop is used to provide custom slots components to the file uploader
+   */
+  slots?: TDsFileUploaderSlots
+  /**
+   slotProps prop is used to provide custom props to the individual slots of the file uploader
+   */
+  slotProps?: TDsFileUploaderSlotProps
+}
+
+export interface IDsFileUploaderDropZoneProps extends DsStackProps {
+  /**
+   * @param {TFileUploaderVariant} variant The variant of file uploader component.
+   * @default 'FULL'
+   */
+  variant?: IDsFileUploaderProps['variant']
+  /**
+   * The `iconProps` component to be used for the file uploader.
+   */
   IconProps?: Omit<DsRemixIconProps, 'ref'>
-  titleButtonText?: React.ReactNode
-  TitleButtonProps?: Omit<DsButtonProps, 'ref'>
-  descriptionTypograpghyText?: React.ReactNode
-  DescriptionTypograpghyProps?: DsTypographyProps
-
+  /**
+   * To override title text in dropbox.
+   */
+  title?: string
+  /**
+   * To override description text in dropbox.
+   */
+  description?: string | string[]
+  /**
+   * To override props passed to input element
+   */
   InputProps?: DsInputProps['inputProps']
+  /**
+   * This prop can be used to toggle the disabled state of the file uploaded.
+   */
+  disabled?: boolean
 }
 
-export interface DsFileUploaderState {
-  files: File[]
+export interface IDsFileUploaderItemSegmentProps extends DsStackProps {
+  /**
+   * This prop is used to provide custom label to the segments
+   */
+  label?: string
+  /**
+   * This prop is used to switch the visibility of delete button in a particular segment
+   */
+  showDeleteIcon?: boolean
+  /**
+   * This prop is used to switch the visibility of preview button in a particular segment
+   */
+  showPreviewIcon?: boolean
+  /**
+   * This prop is used to switch the visibility of download button in a particular segment
+   */
+  showDownloadIcon?: boolean
+
+  /**
+   * This prop is used to supply files to the segment
+   */
+  files?: TFile<TContentType> | TFile<TContentType>[]
+  /**
+   * Callback fired when an preview button is clicked for an existing file.
+   *
+   * @param {string} name The name provided to the component.
+   * @param {TFile<TContentType>} [file] This would be the valid `TFile<TContentType>` type objects selected with its content value depending on `contentType` props or as provided in value.
+   */
+  onPreview?: IDsFileUploaderProps['onPreview']
+  /**
+   * Callback fired when an existing file is removed.
+   *
+   * @param {string} name The name provided to the component.
+   * @param {TFile<TContentType>} [file] This would be the valid `TFile<TContentType>` type objects selected with its content value depending on `contentType` props or as provided in value.
+   */
+  onDelete?: IDsFileUploaderProps['onDelete']
+  /**
+   * Callback fired when an download button is clicked for an existing file.
+   *
+   * @param {string} name The name provided to the component.
+   * @param {TFile<TContentType>} [file] This would be the valid `TFile<TContentType>` type objects selected with its content value depending on `contentType` props or as provided in value.
+   */
+  onDownload?: IDsFileUploaderProps['onDownload']
+  /**
+   slots prop is used to provide custom slots components to the file uploader
+   */
+  slots?: IDsFileUploaderProps['slots']
 }
 
-export const DsFileUploaderDefaultProps: DsFileUploaderProps = {
+export interface IDsFileUploaderActionButtonProps extends DsIconButtonProps {
+  /**
+   * To override delete icon in files
+   */
+  IconProps?: Omit<DsRemixIconProps, 'ref'>
+}
+
+export type TDsFileUploaderSlots = {
+  /**
+   This prop is used to provide custom slot component to the drop zone of the component
+   */
+  DropZone?: ElementType<IDsFileUploaderDropZoneProps>
+  /**
+   This prop is used to provide custom slot component to the selected segment of the component
+   */
+  SelectedItemSegment?: ElementType<IDsFileUploaderItemSegmentProps>
+  /**
+   This prop is used to provide custom slot component to the uploaded segment of the component
+   */
+  UploadedItemSegment?: ElementType<IDsFileUploaderItemSegmentProps>
+  /**
+   This prop is used to provide custom slot component to the delete button of the component
+   */
+  DeleteButton?: ElementType<IDsFileUploaderActionButtonProps>
+  /**
+   This prop is used to provide custom slot component to the preview button of the component
+   */
+  PreviewButton?: ElementType<IDsFileUploaderActionButtonProps>
+  /**
+   This prop is used to provide custom slot component to the download button of the component
+   */
+  DownloadButton?: ElementType<IDsFileUploaderActionButtonProps>
+}
+
+export type TDsFileUploaderSlotProps = {
+  /**
+   This prop is used to provide custom props drop zone of the component
+   */
+  DropZone?: IDsFileUploaderDropZoneProps
+  /**
+   This prop is used to provide custom props selected segment of the component
+   */
+  SelectedItemSegment?: IDsFileUploaderItemSegmentProps
+  /**
+   This prop is used to provide custom props uploaded segment of the component
+   */
+  UploadedItemSegment?: IDsFileUploaderItemSegmentProps
+  /**
+   This prop is used to provide custom props delete button of the component
+   */
+  DeleteButton?: IDsFileUploaderActionButtonProps
+  /**
+   This prop is used to provide custom props preview button of the component
+   */
+  PreviewButton?: IDsFileUploaderActionButtonProps
+  /**
+   This prop is used to provide custom props download button of the component
+   */
+  DownloadButton?: IDsFileUploaderActionButtonProps
+}
+
+export const DsFileUploaderDefaultProps: IDsFileUploaderProps<
+  TMultiple,
+  'FILE'
+> = {
   name: '',
   onChange: () => {},
-  titleButtonText: 'Upload document',
-  descriptionTypograpghyText: 'Click to browse or drop here to upload'
+  value: undefined,
+  accept: '*',
+  variant: 'FULL',
+  slots: {
+    DropZone: DsFileUploaderDropZone,
+    UploadedItemSegment: DsFileUploaderUploadedFilesSegment,
+    SelectedItemSegment: DsFileUploaderSelectedFilesSegment,
+    DeleteButton: DsFileUploaderActionButton,
+    PreviewButton: DsFileUploaderActionButton,
+    DownloadButton: DsFileUploaderActionButton
+  },
+  slotProps: {
+    SelectedItemSegment: {
+      label: 'Selected Documents',
+      showDeleteIcon: true
+    },
+    UploadedItemSegment: {
+      label: 'Uploaded documents',
+      showDeleteIcon: true
+    }
+  }
 }
 
-export const DsFileUploaderDefaultState: DsFileUploaderState = {
-  files: []
-}
+export const DsFileUploaderDropzoneDefaultProps: IDsFileUploaderDropZoneProps =
+  {
+    variant: DsFileUploaderDefaultProps.variant,
+    title: 'Upload document',
+    description: 'Click to browse or drop here to upload'
+  }

--- a/src/Components/DsFileUploader/DsFileUploaderPreview/DsFileUploaderImagePreview.Component.tsx
+++ b/src/Components/DsFileUploader/DsFileUploaderPreview/DsFileUploaderImagePreview.Component.tsx
@@ -23,13 +23,17 @@ export const DsFileUploaderImagePreview = ({
 
     const loadImage = async () => {
       try {
-        if (typeof file.content === 'string') {
+        let content = file.content
+        if (typeof content === 'string') {
           const img = new Image()
-          img.src = file.content
+          if (!content.startsWith('data:')) {
+            content = `data:${file.type};base64,${content}`
+          }
+          img.src = content
           img.onload = () => isMounted && setSrc(img.src)
           img.onerror = () => isMounted && setSrc(null)
-        } else if (file.content instanceof File) {
-          const url = URL.createObjectURL(file.content)
+        } else if (content instanceof File) {
+          const url = URL.createObjectURL(content)
           const img = new Image()
           img.src = url
           img.onload = () => isMounted && setSrc(url)

--- a/src/Components/DsFileUploader/DsFileUploaderPreview/DsFileUploaderImagePreview.Component.tsx
+++ b/src/Components/DsFileUploader/DsFileUploaderPreview/DsFileUploaderImagePreview.Component.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react'
+import { TContentType, TFile } from '../DsFileUploader.Types'
+import { DsImage } from '../../DsImage'
+import { DsRemixIcon } from '../../DsRemixIcon'
+
+interface DsFileUploaderImagePreview {
+  file: TFile<TContentType>
+}
+
+/**
+ * This component is responsible for rendering a preview of an uploaded image file.
+ * If the file content is valid and can be loaded, it shows the image preview.
+ * Otherwise, it displays a fallback icon.
+ */
+
+export const DsFileUploaderImagePreview = ({
+  file
+}: DsFileUploaderImagePreview) => {
+  const [src, setSrc] = useState<string | null>(null)
+
+  useEffect(() => {
+    let isMounted = true
+
+    const loadImage = async () => {
+      try {
+        if (typeof file.content === 'string') {
+          const img = new Image()
+          img.src = file.content
+          img.onload = () => isMounted && setSrc(img.src)
+          img.onerror = () => isMounted && setSrc(null)
+        } else if (file.content instanceof File) {
+          const url = URL.createObjectURL(file.content)
+          const img = new Image()
+          img.src = url
+          img.onload = () => isMounted && setSrc(url)
+          img.onerror = () => {
+            if (isMounted) setSrc(null)
+            URL.revokeObjectURL(url)
+          }
+        }
+      } catch {
+        if (isMounted) setSrc(null)
+      }
+    }
+
+    loadImage()
+
+    return () => {
+      isMounted = false
+    }
+  }, [file])
+
+  if (src) {
+    return (
+      <DsImage
+        srcSet={[{ src: src, alt: file.name }]}
+        width='32px'
+        height='32px'
+        WrapperProps={{
+          sx: {
+            width: '32px',
+            height: '32px'
+          }
+        }}
+        style={{
+          objectFit: 'cover',
+          borderRadius: 'var(--ds-radius-quickFreeze)'
+        }}
+      />
+    )
+  }
+  return (
+    <DsRemixIcon
+      sx={{
+        p: 'var(--ds-spacing-quickFreeze)',
+        borderRadius: 'var(--ds-radius-quickFreeze)',
+        backgroundColor: 'var(--ds-colour-neutral2)',
+        color: 'var(--ds-colour-actionTertiary)'
+      }}
+      className='ri-image-2-line'
+    />
+  )
+}

--- a/src/Components/DsFileUploader/DsFileUploaderPreview/DsFileUploaderImagePreview.Component.tsx
+++ b/src/Components/DsFileUploader/DsFileUploaderPreview/DsFileUploaderImagePreview.Component.tsx
@@ -47,6 +47,9 @@ export const DsFileUploaderImagePreview = ({
 
     return () => {
       isMounted = false
+      if (src && src.startsWith('blob:')) {
+        URL.revokeObjectURL(src)
+      }
     }
   }, [file])
 

--- a/src/Components/DsFileUploader/DsFileUploaderPreview/DsFileUploaderPreview.Component.tsx
+++ b/src/Components/DsFileUploader/DsFileUploaderPreview/DsFileUploaderPreview.Component.tsx
@@ -1,0 +1,41 @@
+import { DsRemixIcon } from '../../DsRemixIcon'
+import { TContentType, TFile } from '../DsFileUploader.Types'
+import { DsFileUploaderImagePreview } from './DsFileUploaderImagePreview.Component'
+
+interface IDsFileUploaderPreviewProps {
+  file: TFile<TContentType>
+}
+
+/**
+ * DsFileUploaderPreview is a functional component that renders an appropriate preview
+ * based on the MIME type of the uploaded file.
+ *
+ * - For image files (e.g., image/jpeg, image/png), it shows an actual image preview.
+ * - For video files, it shows a video icon.
+ * - For all other file types, it shows a generic file icon.
+ */
+export const DsFileUploaderPreview = ({
+  file
+}: IDsFileUploaderPreviewProps) => {
+  const { type: mimeType } = file
+  const IMAGE_REGEX = new RegExp('^image/.*')
+  const VIDEO_REGEX = new RegExp('^video/.*')
+
+  if (IMAGE_REGEX.test(mimeType)) {
+    return <DsFileUploaderImagePreview file={file} />
+  }
+  const iconName = VIDEO_REGEX.test(mimeType)
+    ? 'ri-video-line'
+    : 'ri-file-list-2-line'
+  return (
+    <DsRemixIcon
+      sx={{
+        p: 'var(--ds-spacing-quickFreeze)',
+        borderRadius: 'var(--ds-radius-quickFreeze)',
+        backgroundColor: 'var(--ds-colour-neutral2)',
+        color: 'var(--ds-colour-actionTertiary)'
+      }}
+      className={iconName}
+    />
+  )
+}

--- a/src/Components/DsFileUploader/FileUploaderFiles.tsx
+++ b/src/Components/DsFileUploader/FileUploaderFiles.tsx
@@ -1,0 +1,112 @@
+import { DsBox } from '../DsBox'
+import { DsStack } from '../DsStack'
+import { DsTypography } from '../DsTypography'
+import {
+  DsFileUploaderDefaultProps,
+  TContentType,
+  type IDsFileUploaderItemSegmentProps,
+  type TFile
+} from './DsFileUploader.Types'
+import { DsFileUploaderPreview } from './DsFileUploaderPreview/DsFileUploaderPreview.Component'
+import { humanizeFileSize } from './helpers'
+
+const FileUploaderFiles = (inProps: IDsFileUploaderItemSegmentProps) => {
+  const mergedSlotProps = {
+    ...DsFileUploaderDefaultProps.slots,
+    ...inProps.slots
+  }
+
+  const props = { ...inProps, slots: mergedSlotProps }
+
+  const {
+    files,
+    onPreview,
+    onDelete,
+    onDownload,
+    showDeleteIcon,
+    showDownloadIcon,
+    showPreviewIcon,
+    slots = {}
+  } = props
+
+  const { DownloadButton, PreviewButton, DeleteButton } = slots
+
+  if (!files) {
+    return null
+  }
+
+  const renderFile = (file: TFile<TContentType>, index: number) => {
+    return (
+      <DsStack
+        key={`${file?.name}-${index}`}
+        direction='row'
+        spacing='var(--ds-spacing-bitterCold)'
+        alignItems='center'
+        sx={{
+          p: 'var(--ds-spacing-bitterCold)',
+          borderRadius: 'var(--ds-radius-glacial)',
+          borderWidth: '1px',
+          borderStyle: 'solid',
+          borderColor: 'var(--ds-colour-strokeDefault)',
+          backgroundColor: 'var(--ds-colour-surfacePrimary)',
+          cursor: 'pointer',
+          '&:hover:not(:has(.delete-icon:hover, .action-icon:hover))': {
+            borderColor: 'var(--ds-colour-strokeSecondarySelected)',
+            backgroundColor: 'var(--ds-colour-stateSelectedSecondaryHover)'
+          }
+        }}
+      >
+        <DsFileUploaderPreview file={file} />
+        <DsBox
+          sx={{
+            display: 'flex',
+            flexGrow: 1,
+            minWidth: 0,
+            flexDirection: 'column'
+          }}
+        >
+          <DsTypography component='div' variant='bodyBoldSmall' noWrap>
+            {file.name}
+          </DsTypography>
+          <DsTypography
+            component='div'
+            variant='bodyRegularSmall'
+            noWrap
+            sx={{
+              color: 'var(--ds-colour-typoTertiary)'
+            }}
+          >
+            {humanizeFileSize(file.size)}
+          </DsTypography>
+        </DsBox>
+        {showDownloadIcon && DownloadButton && (
+          <DownloadButton
+            IconProps={{ className: 'ri-download-line' }}
+            onClick={() => onDownload && onDownload(file.name, file)}
+          />
+        )}
+        {showPreviewIcon && PreviewButton && (
+          <PreviewButton
+            IconProps={{ className: 'ri-eye-line' }}
+            onClick={() => onPreview && onPreview(file.name, file)}
+          />
+        )}
+
+        {showDeleteIcon && DeleteButton && (
+          <DeleteButton
+            IconProps={{ className: 'ri-delete-bin-line' }}
+            onClick={() => onDelete && onDelete(file.name, file)}
+          />
+        )}
+      </DsStack>
+    )
+  }
+
+  if (!Array.isArray(files)) {
+    return renderFile(files, 0)
+  }
+
+  return files?.map(renderFile)
+}
+
+export default FileUploaderFiles

--- a/src/Components/DsFileUploader/FileUploaderFiles.tsx
+++ b/src/Components/DsFileUploader/FileUploaderFiles.tsx
@@ -26,10 +26,16 @@ const FileUploaderFiles = (inProps: IDsFileUploaderItemSegmentProps) => {
     showDeleteIcon,
     showDownloadIcon,
     showPreviewIcon,
-    slots = {}
+    slots = {},
+    slotProps = {}
   } = props
 
   const { DownloadButton, PreviewButton, DeleteButton } = slots
+  const {
+    DownloadButton: DownloadButtonProps,
+    PreviewButton: PreviewButtonProps,
+    DeleteButton: DeleteButtonProps
+  } = slotProps
 
   if (!files) {
     return null
@@ -41,8 +47,8 @@ const FileUploaderFiles = (inProps: IDsFileUploaderItemSegmentProps) => {
         key={`${file?.name}-${index}`}
         direction='row'
         spacing='var(--ds-spacing-bitterCold)'
-        alignItems='center'
         sx={{
+          alignItems: 'center',
           p: 'var(--ds-spacing-bitterCold)',
           borderRadius: 'var(--ds-radius-glacial)',
           borderWidth: '1px',
@@ -83,12 +89,14 @@ const FileUploaderFiles = (inProps: IDsFileUploaderItemSegmentProps) => {
           <DownloadButton
             IconProps={{ className: 'ri-download-line' }}
             onClick={() => onDownload && onDownload(file.name, file)}
+            {...DownloadButtonProps}
           />
         )}
         {showPreviewIcon && PreviewButton && (
           <PreviewButton
             IconProps={{ className: 'ri-eye-line' }}
             onClick={() => onPreview && onPreview(file.name, file)}
+            {...PreviewButtonProps}
           />
         )}
 
@@ -96,6 +104,7 @@ const FileUploaderFiles = (inProps: IDsFileUploaderItemSegmentProps) => {
           <DeleteButton
             IconProps={{ className: 'ri-delete-bin-line' }}
             onClick={() => onDelete && onDelete(file.name, file)}
+            {...DeleteButtonProps}
           />
         )}
       </DsStack>

--- a/src/Components/DsFileUploader/Slots/DsFileUploaderActionButton.Component.tsx
+++ b/src/Components/DsFileUploader/Slots/DsFileUploaderActionButton.Component.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { IDsFileUploaderActionButtonProps } from '../DsFileUploader.Types'
+import { DsIconButton } from '../../DsIconButton'
+import { DsRemixIcon } from '../../DsRemixIcon'
+
+/**
+ * DsFileUploaderActionButton
+ *
+ * A reusable icon button component used within the FileUploader for actions like
+ * delete, download, preview, etc. It wraps a `DsRemixIcon` inside a `DsIconButton`
+ * and accepts customization through props.
+ */
+export const DsFileUploaderActionButton: React.FC<
+  IDsFileUploaderActionButtonProps
+> = ({ onClick, IconProps, ...iconButtonProps }) => {
+  return (
+    <DsIconButton
+      onClick={onClick}
+      sx={{
+        p: 'var(--ds-spacing-glacial)',
+        borderRadius: 'var(--ds-radius-quickFreeze)',
+        backgroundColor: 'var(--ds-colour-surfaceSecondary)',
+        ...iconButtonProps.sx
+      }}
+      {...iconButtonProps}
+    >
+      <DsRemixIcon fontSize='bitterCold' {...IconProps} />
+    </DsIconButton>
+  )
+}

--- a/src/Components/DsFileUploader/Slots/DsFileUploaderDropZone.tsx
+++ b/src/Components/DsFileUploader/Slots/DsFileUploaderDropZone.tsx
@@ -1,0 +1,200 @@
+import { DsBox } from '../../DsBox'
+import { DsButton } from '../../DsButton'
+import { DsInput } from '../../DsInput'
+import { DsRemixIcon } from '../../DsRemixIcon'
+import { DsStack, DsStackProps } from '../../DsStack'
+import { DsTypography } from '../../DsTypography'
+import {
+  DsFileUploaderDropzoneDefaultProps,
+  IDsFileUploaderDropZoneProps
+} from '../DsFileUploader.Types'
+
+/**
+ * DsFileUploaderDropZone
+ *
+ * This component renders a drop zone area where users can drag & drop files
+ * or click to upload using a hidden input field. It supports two layout variants:
+ * - 'DEFAULT': Large button with drag and drop space area
+ * - 'COMPRESSED': Smaller area and button size to save space
+ */
+export const DsFileUploaderDropZone = (
+  inProps: IDsFileUploaderDropZoneProps
+) => {
+  const props = {
+    ...DsFileUploaderDropzoneDefaultProps,
+    ...inProps
+  }
+  const {
+    variant,
+    IconProps,
+    title,
+    description,
+    InputProps,
+    disabled,
+    ...restDsStackProps
+  } = props
+
+  const isCompressed = variant === 'COMPRESSED'
+
+  const renderDescription = () => {
+    if (!description) return null
+
+    const isArray = Array.isArray(description)
+    const isString = typeof description === 'string'
+    const shouldRenderCompressedArray = isArray && isCompressed
+    const shouldRenderString = isString
+
+    if (!shouldRenderCompressedArray && !shouldRenderString) return null
+
+    const color = `var(--ds-colour-${isCompressed ? 'typoPrimary' : 'typoTertiary'})`
+    const containerProps: DsStackProps = {
+      direction: isCompressed ? 'row' : undefined,
+      justifyContent: isCompressed
+        ? isArray && description.length > 1
+          ? 'space-between'
+          : 'center'
+        : 'center',
+      alignItems: isCompressed ? 'center' : undefined,
+      textAlign: isCompressed ? 'center' : undefined,
+      pb: isCompressed ? undefined : 'var(--ds-spacing-bitterCold)',
+      sx: isCompressed
+        ? {
+            py: 'var(--ds-spacing-quickFreeze)',
+            px: 'var(--ds-spacing-glacial)',
+            backgroundColor: 'var(--ds-colour-surfaceSecondary)',
+            borderRadius: 'var(--ds-radius-quickFreeze)'
+          }
+        : undefined
+    }
+
+    const renderTypographies = () => {
+      const descList = isString ? [description] : description
+      return descList.map((desc, index) => (
+        <DsTypography
+          key={index}
+          variant='bodyRegularSmall'
+          align='center'
+          color={color}
+        >
+          {desc}
+        </DsTypography>
+      ))
+    }
+
+    return (
+      <DsStack key='dropzone-description' {...containerProps}>
+        {renderTypographies()}
+      </DsStack>
+    )
+  }
+
+  return [
+    <DsBox
+      key='dropzone-box'
+      sx={{
+        width: '100%',
+        position: 'relative',
+        borderRadius: 'var(--ds-radius-glacial)',
+        borderWidth: '1px',
+        borderStyle: 'dashed',
+        borderColor: 'var(--ds-colour-strokeDefault)',
+        backgroundColor: disabled
+          ? 'var(--ds-colour-stateDisabledSurface)'
+          : 'var(--ds-colour-surfacePrimary)',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        '&:hover': {
+          borderColor: disabled
+            ? 'var(--ds-colour-strokeDefault)'
+            : 'var(--ds-colour-strokeSecondarySelected)',
+          '.dropzone-content-wrapper': {
+            backgroundColor: disabled
+              ? 'var(--ds-colour-stateDisabledSurface)'
+              : isCompressed
+                ? 'var(--ds-colour-surfaceSecondary)'
+                : 'var(--ds-colour-stateSelectedSecondaryHover)'
+          }
+        }
+      }}
+    >
+      <DsStack
+        className='dropzone-content-wrapper'
+        flexDirection={isCompressed ? 'row' : 'column'}
+        gap='var(--ds-spacing-quickFreeze)'
+        justifyContent='center'
+        alignItems='center'
+        {...restDsStackProps}
+        sx={{
+          borderRadius: isCompressed
+            ? 'var(--ds-radius-quickFreeze)'
+            : 'var(--ds-radius-glacial)',
+          m: isCompressed
+            ? 'var(--ds-spacing-frostbite)'
+            : 'var(--ds-spacing-zero)',
+          px: isCompressed
+            ? 'var(--ds-spacing-glacial)'
+            : 'var(--ds-spacing-bitterCold)',
+          pt: isCompressed
+            ? 'var(--ds-spacing-zero)'
+            : 'var(--ds-spacing-bitterCold)',
+          backgroundColor: disabled
+            ? 'var(--ds-colour-stateDisabledSurface)'
+            : isCompressed
+              ? 'var(--ds-colour-surfaceSecondary)'
+              : 'var(--ds-colour-surfacePrimary)',
+          '&:hover': {
+            backgroundColor: isCompressed
+              ? 'var(--ds-colour-surfaceSecondary)'
+              : 'var(--ds-colour-stateSelectedSecondaryHover)'
+          },
+          ...restDsStackProps?.sx
+        }}
+      >
+        <DsRemixIcon
+          className={isCompressed ? 'ri-upload-line' : 'ri-upload-cloud-2-line'}
+          fontSize={isCompressed ? 'frostbite' : 'mild'}
+          color={disabled ? 'disabled' : 'secondary'}
+          {...IconProps}
+        />
+        <DsButton disabled={disabled} variant='text' color='secondary'>
+          {title}
+        </DsButton>
+        {!isCompressed && renderDescription()}
+      </DsStack>
+
+      <DsInput
+        type='file'
+        slot='input'
+        disabled={disabled}
+        sx={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          height: '100%',
+          width: '100%',
+          opacity: 0,
+          margin: 'var(--ds-spacing-zero) !important'
+        }}
+        onChange={InputProps?.onChange}
+        onDrop={InputProps?.onDrop as React.DragEventHandler<HTMLInputElement>}
+        onDragOver={
+          InputProps?.onDragOver as React.DragEventHandler<HTMLInputElement>
+        }
+        disableUnderline
+        inputProps={{
+          title,
+          value: '',
+          ...InputProps,
+          accept: InputProps?.accept,
+          multiple: InputProps?.multiple,
+          style: {
+            height: '100%',
+            width: '100%',
+            cursor: disabled ? 'not-allowed' : 'pointer',
+            ...InputProps?.style
+          }
+        }}
+      />
+    </DsBox>,
+    isCompressed && renderDescription()
+  ]
+}

--- a/src/Components/DsFileUploader/Slots/DsFileUploaderSelectedFilesSegment.tsx
+++ b/src/Components/DsFileUploader/Slots/DsFileUploaderSelectedFilesSegment.tsx
@@ -1,0 +1,44 @@
+import { DsStack } from '../../DsStack'
+import { DsTypography } from '../../DsTypography'
+import {
+  DsFileUploaderDefaultProps,
+  TDsFileUploaderSlotProps
+} from '../DsFileUploader.Types'
+import { cloneElement, isValidElement } from 'react'
+
+/**
+ * DsFileUploaderSelectedFilesSegment
+ *
+ * This component is a wrapper to render a labeled section
+ * for displaying selected files in a scrollable container.
+ *
+ * It supports slot-level customization via props and merges them with default values.
+ */
+export const DsFileUploaderSelectedFilesSegment = (
+  inProps: TDsFileUploaderSlotProps['SelectedItemSegment']
+) => {
+  const props = {
+    ...DsFileUploaderDefaultProps.slotProps?.SelectedItemSegment,
+    ...inProps
+  }
+
+  const { label, children } = props
+
+  return (
+    <DsStack spacing='var(--ds-spacing-frostbite)'>
+      <DsTypography
+        py='var(--ds-spacing-glacial)'
+        variant='subheadingSemiboldDefault'
+        color='var(--ds-colour-typoSecondary)'
+      >
+        {label}
+      </DsTypography>
+      <DsStack
+        spacing='var(--ds-spacing-frostbite)'
+        sx={{ maxHeight: '440px', overflowY: 'auto' }}
+      >
+        {isValidElement(children) && cloneElement(children, { ...props })}
+      </DsStack>
+    </DsStack>
+  )
+}

--- a/src/Components/DsFileUploader/Slots/DsFileUploaderUploadedFilesSegment.tsx
+++ b/src/Components/DsFileUploader/Slots/DsFileUploaderUploadedFilesSegment.tsx
@@ -1,0 +1,43 @@
+import { DsStack } from '../../DsStack'
+import { DsTypography } from '../../DsTypography'
+import {
+  DsFileUploaderDefaultProps,
+  TDsFileUploaderSlotProps
+} from '../DsFileUploader.Types'
+import { cloneElement, isValidElement } from 'react'
+
+/**
+ * DsFileUploaderSelectedFilesSegment
+ *
+ * This component is a wrapper to render a labeled section
+ * for displaying uploaded files in a scrollable container.
+ *
+ * It supports slot-level customization via props and merges them with default values.
+ */
+export const DsFileUploaderUploadedFilesSegment = (
+  inProps: TDsFileUploaderSlotProps['UploadedItemSegment']
+) => {
+  const props = {
+    ...DsFileUploaderDefaultProps.slotProps?.UploadedItemSegment,
+    ...inProps
+  }
+
+  const { label, children } = props
+  return (
+    <DsStack spacing='var(--ds-spacing-frostbite)'>
+      <DsTypography
+        py='var(--ds-spacing-glacial)'
+        variant='subheadingSemiboldDefault'
+        color='var(--ds-colour-typoSecondary)'
+      >
+        {label}
+      </DsTypography>
+      <DsStack
+        spacing='var(--ds-spacing-frostbite)'
+        sx={{ maxHeight: '440px', overflowY: 'auto' }}
+      >
+        {isValidElement(children) && cloneElement(children, { ...props })}
+      </DsStack>
+    </DsStack>
+  )
+}

--- a/src/Components/DsFileUploader/converter.ts
+++ b/src/Components/DsFileUploader/converter.ts
@@ -1,0 +1,32 @@
+import type { TContentType, TFile } from './DsFileUploader.Types'
+
+export const fileToFileUploader = async (
+  file: File,
+  contentType: TContentType
+): Promise<TFile<TContentType>> => {
+  const { name, type, size } = file
+
+  let content: TFile<TContentType>['content'] = file
+  if (contentType === 'BASE64') {
+    content = await fileToBase64(file)
+    content = content.replace('data:image/png;base64,', '')
+  }
+
+  const fileUploader: TFile<TContentType> = {
+    name,
+    type,
+    size,
+    content
+  }
+
+  return fileUploader
+}
+
+const fileToBase64 = (file: File): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.readAsDataURL(file)
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = error => reject(error)
+  })
+}

--- a/src/Components/DsFileUploader/converter.ts
+++ b/src/Components/DsFileUploader/converter.ts
@@ -9,7 +9,10 @@ export const fileToFileUploader = async (
   let content: TFile<TContentType>['content'] = file
   if (contentType === 'BASE64') {
     content = await fileToBase64(file)
-    content = content.replace('data:image/png;base64,', '')
+
+    if (typeof content === 'string' && content.startsWith('data:')) {
+      content = content.substring(content.indexOf(',') + 1)
+    }
   }
 
   const fileUploader: TFile<TContentType> = {

--- a/src/Components/DsFileUploader/helpers.tsx
+++ b/src/Components/DsFileUploader/helpers.tsx
@@ -1,0 +1,138 @@
+import type {
+  IDsFileUploaderProps,
+  TContentType,
+  TErrorFile,
+  TErrorValue,
+  TFile,
+  TMultiple,
+  TValue
+} from './DsFileUploader.Types'
+import { DsFileUploaderImagePreview } from './DsFileUploaderPreview/DsFileUploaderImagePreview.Component'
+import { getFileValidator } from './validator'
+import { fileToFileUploader } from './converter'
+import { DsRemixIcon } from '../DsRemixIcon'
+
+export const mergeProps = <T extends Record<string, any>>(
+  inProps: Partial<T>,
+  defaultProps: T
+): T => {
+  return {
+    ...defaultProps,
+    ...inProps,
+    slots: {
+      ...defaultProps.slots,
+      ...inProps.slots
+    },
+    slotProps: {
+      ...defaultProps.slotProps,
+      ...inProps.slotProps,
+      SelectedItemSegment: {
+        ...defaultProps.slotProps?.SelectedItemSegment,
+        ...inProps.slotProps?.SelectedItemSegment
+      },
+      UploadedItemSegment: {
+        ...defaultProps.slotProps?.UploadedItemSegment,
+        ...inProps.slotProps?.UploadedItemSegment
+      },
+      DropZone: {
+        ...defaultProps?.slotProps?.DropZone,
+        ...inProps.slotProps?.DropZone
+      }
+    }
+  }
+}
+
+export const getFileTypeIcon = <ContentType extends TContentType>(
+  file: TFile<ContentType>
+) => {
+  const { type: mimeType } = file
+  const IMAGE_REGEX = new RegExp('^image/.*')
+  const VIDEO_REGEX = new RegExp('^video/.*')
+
+  if (IMAGE_REGEX.test(mimeType)) {
+    return <DsFileUploaderImagePreview file={file} />
+  } else if (VIDEO_REGEX.test(mimeType)) {
+    return <DsRemixIcon className='ri-video-line' />
+  } else {
+    return <DsRemixIcon className='ri-file-list-2-line' />
+  }
+}
+
+export const humanizeFileSize = (bytes: number, decimals: number = 2) => {
+  if (!+bytes) return '0 Bytes'
+
+  const k = 1024
+  const dm = decimals < 0 ? 0 : decimals
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`
+}
+
+export const getDefaultValue = <
+  Multiple extends TMultiple,
+  ContentType extends TContentType
+>(
+  props: IDsFileUploaderProps<Multiple, ContentType>
+): TValue<Multiple, ContentType> | null => {
+  const { value, multiple } = props
+  if (value) {
+    return value
+  }
+
+  if (multiple) {
+    return [] as TFile<ContentType>[] as IDsFileUploaderProps<
+      Multiple,
+      ContentType
+    >['value']
+  }
+
+  return null
+}
+
+export const getValidProcessedFile = async <
+  Multiple extends TMultiple,
+  ContentType extends TContentType
+>(
+  filesToProcess: FileList,
+  files: TValue<Multiple, ContentType> | null,
+  accept: string,
+  minSize?: number,
+  maxSize?: number,
+  contentType?: TContentType
+): Promise<{
+  valid: TValue<Multiple, ContentType>
+  invalid: TErrorValue<Multiple, ContentType>
+}> => {
+  const validator = getFileValidator(accept, minSize, maxSize)
+
+  const isMultiple = Array.isArray(files)
+  const validFiles = isMultiple ? [...files] : []
+  const invalidFiles: TErrorValue<true, ContentType> = []
+
+  const fileList = [...filesToProcess]
+
+  for (const file of fileList) {
+    const fileUploader = await fileToFileUploader(file, contentType || 'FILE')
+    const errorCode = validator(file)
+    if (!errorCode) {
+      validFiles.unshift(fileUploader)
+    } else {
+      const temp: TErrorFile<ContentType> = {
+        file: fileUploader,
+        errorCode
+      }
+      invalidFiles.push(temp)
+    }
+  }
+
+  const valid = isMultiple ? validFiles : validFiles[0]
+
+  const invalid = (isMultiple ? invalidFiles : invalidFiles[0]) as TErrorValue<
+    Multiple,
+    ContentType
+  >
+
+  return { valid, invalid }
+}

--- a/src/Components/DsFileUploader/validator.ts
+++ b/src/Components/DsFileUploader/validator.ts
@@ -1,0 +1,55 @@
+import { ERROR_CODES, type TErrorCodes } from './DsFileUploader.Types'
+
+export const getFileValidator = (
+  accept: string,
+  minSize: number | undefined = 0,
+  maxSize: number | undefined = Infinity
+) => {
+  const validateFileType = getFileTypeValidator(accept)
+
+  return (file: File): TErrorCodes | undefined => {
+    const { size, type } = file
+
+    if (!validateMinSize(size, minSize)) {
+      return ERROR_CODES.FILE_SIZE_BELOW_MIN
+    }
+
+    if (!validateMaxSize(size, maxSize)) {
+      return ERROR_CODES.MAX_FILE_SIZE_EXCEEDED
+    }
+
+    if (!validateFileType(type)) {
+      return ERROR_CODES.INVALID_FILE_TYPE
+    }
+  }
+}
+
+const validateMinSize = (size: number, minSize: number | undefined = 0) => {
+  return size >= minSize
+}
+
+const validateMaxSize = (
+  size: number,
+  maxSize: number | undefined = Infinity
+) => {
+  return size <= maxSize
+}
+
+const getFileTypeValidator = (accept: string) => {
+  // Escape dots and replace wildcards with .* for regex
+  const typesPattern = accept
+    .split(',')
+    .map(type => type.trim())
+    .map(type => type.replace(/\./g, '\\.').replace(/\*/g, '.*'))
+    .join('|')
+
+  // Create a regex with start and end anchors
+  const typesRegex = new RegExp(`^(${typesPattern})$`)
+
+  // Validator function
+  const validateFileType = (mimeType: string) => {
+    return typesRegex.test(mimeType)
+  }
+
+  return validateFileType
+}


### PR DESCRIPTION
## 📝 Summary
In this PR we have added a compressed verison of file uploader according to new designs, user can now also make file uploader asa controlled variant because of which there are 2 segregated lists uploaded files and selected files, we have also added slots and slotProps for the uploader to custoomize button dropzone etc.

## 📌 Related Issue
NA

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [x] Updated documentation/comments where needed
- [x] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [ ] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:
1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/rreact-design-system -> dist

1. Go to...
2. Click on...
3. Observe...

## 📸 Screenshots / Videos (if applicable)

Compressed verison with description-
<img width="522" height="137" alt="Screenshot 2025-07-17 at 1 24 00 PM" src="https://github.com/user-attachments/assets/2629987c-c8fc-48dc-85f5-d416def83c67" />

Segregated list for selected and previously uploaded files-
<img width="525" height="395" alt="Screenshot 2025-07-17 at 1 24 32 PM" src="https://github.com/user-attachments/assets/181fa08b-9788-4959-a35e-f6c9db45c356" />

Older Full version still present-
<img width="541" height="439" alt="Screenshot 2025-07-17 at 1 25 39 PM" src="https://github.com/user-attachments/assets/dc5fe949-f3b7-4b70-924c-b34a4520fac0" />


## 🧩 Notes
Any extra context, edge cases, or known limitations.