### PR TITLE
Fixed Bug: DsTooltip slots and slotPtops passed in tooltip component

### DIFF
--- a/src/Components/DsTooltip/DsTooltip.Component.tsx
+++ b/src/Components/DsTooltip/DsTooltip.Component.tsx
@@ -33,14 +33,14 @@ export const CustomTooltip = <
     )
   }
 
-  const { heading, description, slots, slotProps, children, ...tooltipProps } =
+  const { slots, slotProps, children, ...tooltipProps } =
     props
 
   const WrapperComponent = slots?.wrapper || React.Fragment
   const wrapperProps = slotProps?.wrapper || {}
 
   return (
-    <Tooltip title={renderTitle()} {...tooltipProps}>
+    <Tooltip slots={slots} slotProps={slotProps} title={renderTitle()} {...tooltipProps}>
       <WrapperComponent {...wrapperProps}>{children || null}</WrapperComponent>
     </Tooltip>
   )


### PR DESCRIPTION
## 📝 Summary
Bug fix for DsTooltip, slots and slotProps were destructured and not passed to the Tooltip component

## 📌 Related Issue
NA

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [ ] Updated documentation/comments where needed
- [x] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [x] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:

1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/rreact-design-system -> dist

## 📸 Screenshots / Videos (if applicable)
NA

## 🧩 Notes
Any extra context, edge cases, or known limitations.