### PR TITLE
Fixed Type: DsTextFieldPassword isVisible type made optional

### DIFF
--- a/src/Components/DsTextFieldPassword/DsTextFieldPassword.Types.tsx
+++ b/src/Components/DsTextFieldPassword/DsTextFieldPassword.Types.tsx
@@ -3,7 +3,7 @@ import { DsTextFieldDefaultProps, DsTextFieldProps } from '../DsTextField'
 
 export interface DsTextFieldPasswordProps
   extends Omit<DsTextFieldProps, 'endAdornment'> {
-  isVisible: boolean
+  isVisible?: boolean
   toggleNode?: {
     toShow: React.ReactElement
     toHide: React.ReactElement


### PR DESCRIPTION
## 📝 Summary
Made isVisible props as optional from required as we do not use password textfield as controlled.

## 📌 Related Issue
NA

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [ ] Updated documentation/comments where needed
- [x] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [x] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:

1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/rreact-design-system -> dist

## 📸 Screenshots / Videos (if applicable)

Custom last step header label
NA




## 🧩 Notes
Any extra context, edge cases, or known limitations.