### PR TITLE
Fixed Component: DsAutocomplete default remixicon color fixed

### DIFF
--- a/src/Components/DsAutocomplete/DsAutocomplete.Types.tsx
+++ b/src/Components/DsAutocomplete/DsAutocomplete.Types.tsx
@@ -15,7 +15,7 @@ export const DsAutocompleteDefaultProps: DsAutocompleteProps<
   boolean
 > = {
   popupIcon: <DsRemixIcon className="ri-arrow-down-s-line" />,
-  clearIcon: <DsRemixIcon color="secondary" className="ri-close-line" />,
+  clearIcon: <DsRemixIcon className="ri-close-line" />,
   multiple: false,
   disableClearable: false,
   freeSolo: false,

--- a/src/Components/DsAutocomplete/DsAutocomplete.Types.tsx
+++ b/src/Components/DsAutocomplete/DsAutocomplete.Types.tsx
@@ -15,7 +15,7 @@ export const DsAutocompleteDefaultProps: DsAutocompleteProps<
   boolean
 > = {
   popupIcon: <DsRemixIcon className="ri-arrow-down-s-line" />,
-  clearIcon: <DsRemixIcon className="ri-close-line" />,
+  clearIcon: <DsRemixIcon className="ri-close-fill" />,
   multiple: false,
   disableClearable: false,
   freeSolo: false,


### PR DESCRIPTION
## 📝 Summary
DsAutocomplete had a default clearIcon which has a actionSecondary font color that needs to fixed to primary default color

## 📌 Related Issue
NA

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [ ] Updated documentation/comments where needed
- [x] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [x] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:

1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/rreact-design-system -> dist

## 📸 Screenshots / Videos (if applicable)

Correct clear icon added
<img width="1086" height="91" alt="Screenshot 2025-08-14 at 11 15 06 AM" src="https://github.com/user-attachments/assets/0e0f9b8f-70f4-4801-8eca-1a30e3d57acd" />




## 🧩 Notes
Any extra context, edge cases, or known limitations.