### PR TITLE
Fixed Styles: DsDialog and DsBottomshett top and botom padding fixed

### DIFF
--- a/src/Components/DsBottomSheet/DsBottomSheet.Component.tsx
+++ b/src/Components/DsBottomSheet/DsBottomSheet.Component.tsx
@@ -116,7 +116,7 @@ export const DsBottomSheet: FC<DsBottomSheetProps> = (inProps) => {
           display: 'flex',
           flexDirection: 'column',
           flexGrow: 1,
-          pt: 'var(--ds-spacing-bitterCold)',
+          pt: 'var(--ds-spacing-mild)',
           borderTopLeftRadius: 'var(--ds-radius-bitterCold)',
           borderTopRightRadius: 'var(--ds-radius-bitterCold)',
           ...ContainerProps?.sx

--- a/src/Components/DsBottomSheet/DsBottomSheet.Component.tsx
+++ b/src/Components/DsBottomSheet/DsBottomSheet.Component.tsx
@@ -117,6 +117,7 @@ export const DsBottomSheet: FC<DsBottomSheetProps> = (inProps) => {
           flexDirection: 'column',
           flexGrow: 1,
           pt: 'var(--ds-spacing-mild)',
+          pb: isFlushed ? undefined : 'var(--ds-spacing-bitterCold)',
           borderTopLeftRadius: 'var(--ds-radius-bitterCold)',
           borderTopRightRadius: 'var(--ds-radius-bitterCold)',
           ...ContainerProps?.sx
@@ -185,7 +186,7 @@ export const DsBottomSheet: FC<DsBottomSheetProps> = (inProps) => {
             sx={{
               px: isFlushed ? undefined : 'var(--ds-spacing-bitterCold)',
               mt: 'var(--ds-spacing-bitterCold)',
-              py: isFlushed ? undefined : 'var(--ds-spacing-bitterCold)',
+              pt: isFlushed ? undefined : 'var(--ds-spacing-bitterCold)',
               ...ActionsProps?.sx
             }}
           >

--- a/src/Components/DsDialog/DsDialog.Component.tsx
+++ b/src/Components/DsDialog/DsDialog.Component.tsx
@@ -64,6 +64,12 @@ export const DsDialog: React.FC<DsDialogProps> = inProps => {
       PaperProps={{
         ...PaperProps,
         sx: {
+          pb: isFlushed
+            ? undefined
+            : {
+                xs: 'var(--ds-spacing-bitterCold)',
+                md: 'var(--ds-spacing-warm)'
+              },
           pt: {
             xs: 'var(--ds-spacing-mild)',
             md: 'var(--ds-spacing-warm)'
@@ -169,7 +175,7 @@ export const DsDialog: React.FC<DsDialogProps> = inProps => {
                   xs: 'var(--ds-spacing-bitterCold)',
                   md: 'var(--ds-spacing-warm)'
                 },
-            py: isFlushed
+            pt: isFlushed
               ? undefined
               : {
                   xs: 'var(--ds-spacing-bitterCold)',


### PR DESCRIPTION
## 📝 Summary
DsDialog and DsBottomshett top and botom padding fixed

## 📌 Related Issue
NA

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [ ] Updated documentation/comments where needed
- [x] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [x] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:

1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/rreact-design-system -> dist

## 📸 Screenshots / Videos (if applicable)

DsDialog padding and kicker changes 
<img width="606" height="440" alt="Screenshot 2025-09-09 at 6 48 45 PM" src="https://github.com/user-attachments/assets/455359b7-9566-4a74-a5e0-6fa8b1a85aeb" />




## 🧩 Notes
Any extra context, edge cases, or known limitations.