### PR TITLE
Added Feature: DsBadge disabled prop, color inverse added

### DIFF
--- a/src/Components/DsBadge/DsBadge.Component.ts
+++ b/src/Components/DsBadge/DsBadge.Component.ts
@@ -1,1 +1,0 @@
-export { default as DsBadge } from '@mui/material/Badge'

--- a/src/Components/DsBadge/DsBadge.Component.tsx
+++ b/src/Components/DsBadge/DsBadge.Component.tsx
@@ -1,0 +1,14 @@
+import { forwardRef } from 'react'
+import Badge from '@mui/material/Badge'
+import { DsBadgeProps } from './DsBadge.Types'
+import { useThemeProps } from '@mui/system'
+
+export const DsBadge = forwardRef<HTMLDivElement, DsBadgeProps>((inProps, ref) => {
+
+  const props = useThemeProps({
+    props: inProps,
+    name: 'MuiBadge'
+  })
+
+  return <Badge ref={ref} {...props} />
+})

--- a/src/Components/DsBadge/DsBadge.Overrides.ts
+++ b/src/Components/DsBadge/DsBadge.Overrides.ts
@@ -4,7 +4,6 @@ export const DsBadgeOverrides = {
   MuiBadge: {
     defaultProps: DsBadgeDefaultProps,
     styleOverrides: {
-      // TODO: check it cases build issues
       root: {
         variants:[
           {
@@ -22,7 +21,7 @@ export const DsBadgeOverrides = {
               '& .MuiBadge-badge': {
                 backgroundColor: 'var(--ds-colour-iconDisabled)', 
                 color: 'var(--ds-colour-typoOnSurface)',
-                pointerEvent: 'none'
+                pointerEvents: 'none'
               }
             }
         }

--- a/src/Components/DsBadge/DsBadge.Overrides.ts
+++ b/src/Components/DsBadge/DsBadge.Overrides.ts
@@ -1,9 +1,33 @@
-import { DsBadgeDefaultProps } from './DsBadge.Types'
+import { DsBadgeDefaultProps, DsBadgeProps } from './DsBadge.Types'
 
 export const DsBadgeOverrides = {
   MuiBadge: {
     defaultProps: DsBadgeDefaultProps,
     styleOverrides: {
+      // TODO: check it cases build issues
+      root: {
+        variants:[
+          {
+            props: { color: 'inverse' } as Partial<DsBadgeProps>,
+            style: {
+              '& .MuiBadge-badge': {
+                backgroundColor: 'var(--ds-colour-iconOnSurface)', 
+                color: 'var(--ds-colour-actionSecondary)',
+              }
+          },
+        },
+          {
+            props: { disabled: true } as Partial<DsBadgeProps>,
+            style: {
+              '& .MuiBadge-badge': {
+                backgroundColor: 'var(--ds-colour-iconDisabled)', 
+                color: 'var(--ds-colour-typoOnSurface)',
+                pointerEvent: 'none'
+              }
+            }
+        }
+        ],
+      },
       standard: {
         fontWeight: 'var(--ds-typo-supportRegularInfo-fontWeight)',
         fontSize: 'var(--ds-typo-supportRegularInfo-fontSize)',

--- a/src/Components/DsBadge/DsBadge.Types.ts
+++ b/src/Components/DsBadge/DsBadge.Types.ts
@@ -1,6 +1,11 @@
 import { BadgeProps } from '@mui/material'
 
-export interface DsBadgeProps extends BadgeProps {}
+type TDsBadgeExtendedColor = BadgeProps['color'] | 'inverse'
+
+export interface DsBadgeProps extends Omit<BadgeProps, 'color'> {
+  color?: TDsBadgeExtendedColor
+  disabled?: boolean
+}
 
 export const DsBadgeDefaultProps: DsBadgeProps = {
   color: 'secondary',

--- a/src/Theme/index.ts
+++ b/src/Theme/index.ts
@@ -88,3 +88,10 @@ declare module '@mui/material/styles' {
     shadows: DsShadows
   }
 }
+
+// FIXME: If inverse is being used anywhere else, add it in theme palettee
+declare module '@mui/material/Badge' {
+  interface BadgePropsColorOverrides {
+    inverse: true
+  }
+}

--- a/src/Theme/index.ts
+++ b/src/Theme/index.ts
@@ -89,7 +89,7 @@ declare module '@mui/material/styles' {
   }
 }
 
-// FIXME: If inverse is being used anywhere else, add it in theme palettee
+// If inverse is being used anywhere else, add it in theme palettee
 declare module '@mui/material/Badge' {
   interface BadgePropsColorOverrides {
     inverse: true


### PR DESCRIPTION
## 📝 Summary
DsBadge disabled prop and color inverse added 

## 📌 Related Issue
NA

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [ ] Updated documentation/comments where needed
- [x] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [x] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:

1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/rreact-design-system -> dist

## 📸 Screenshots / Videos (if applicable)

DsBadge disabled prop
<img width="111" height="59" alt="Screenshot 2025-12-04 at 1 57 29 AM" src="https://github.com/user-attachments/assets/0fa54970-e32e-442b-9b4e-923d297155f2" />

DsBadge color inverse
<img width="96" height="72" alt="Screenshot 2025-12-04 at 2 00 07 AM" src="https://github.com/user-attachments/assets/f501dde2-9634-4b43-b983-02be245c1479" />



## 🧩 Notes
Any extra context, edge cases, or known limitations.