### PR TITLE
Fixed Component: DsFab default state color fixed

### DIFF
--- a/src/Components/DsFab/DsFab.Overrides.ts
+++ b/src/Components/DsFab/DsFab.Overrides.ts
@@ -42,6 +42,7 @@ export const DsFabOverrides = {
         ...STATE_STYLES.ACTION_SECONDARY_STATE_SECONDARY
       } as CSSInterpolation,
       default: {
+        color: 'var(--ds-colour-typoPrimary)',
         backgroundColor: 'var(--ds-colour-surfacePrimary)',
         borderWidth: '1px',
         borderStyle: 'solid',


### PR DESCRIPTION
## 📝 Summary
DsFab text colour fixed for colour default

## 📌 Related Issue
NA

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [ ] Updated documentation/comments where needed
- [x] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [x] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:

1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/react-design-system -> dist

## 📸 Screenshots / Videos (if applicable)

DsFab text color fixed
<img width="229" height="160" alt="Screenshot 2026-01-08 at 2 32 49 PM" src="https://github.com/user-attachments/assets/f197ff10-55f1-4545-8524-dd6a3d486029" />



## 🧩 Notes
Any extra context, edge cases, or known limitations.