### PR TITLE
Added Feature: DsBottomSheet added support for illustration

### DIFF
--- a/src/Components/DsBottomSheet/DsBottomSheet.Component.tsx
+++ b/src/Components/DsBottomSheet/DsBottomSheet.Component.tsx
@@ -56,6 +56,8 @@ export const DsBottomSheet: FC<DsBottomSheetProps> = (inProps) => {
     children,
     onClose,
     slotProps,
+    illustration,
+    IllustrationProps,
     ...DrawerProps
   } = props
 
@@ -129,6 +131,19 @@ export const DsBottomSheet: FC<DsBottomSheetProps> = (inProps) => {
           ...ContainerProps?.sx
         }}
       >
+        {illustration && (
+          <DsDialogContent
+            {...IllustrationProps}
+            sx={{
+              px: 'var(--ds-spacing-bitterCold)',
+              marginBottom: 'var(--ds-spacing-mild)',
+              ...IllustrationProps?.sx
+            }}
+          >
+            {illustration}
+          </DsDialogContent>
+        )}
+
         {kicker && (
           <DsTypography
             variant='subheadingSemiboldDefault'

--- a/src/Components/DsBottomSheet/DsBottomSheet.Types.ts
+++ b/src/Components/DsBottomSheet/DsBottomSheet.Types.ts
@@ -9,22 +9,42 @@ import { DsRemixIconProps } from '../DsRemixIcon'
 import { DsTypographyProps } from '../DsTypography'
 
 export interface DsBottomSheetProps extends Omit<DsDrawerProps, 'title'> {
+  /** Small contextual text displayed above the title (e.g., "Confirm Action", "Settings") */
   kicker?: string
+  /** Main heading text for the bottom sheet content */
   title?: string
+  /** Supporting text content displayed below the title for additional context */
   description?: string
+  /** Whether to display the close (×) button in the header. @default true */
   showClose?: boolean
+  /** Content for the primary action button (typically the main action) */
   primaryButtonText?: DsButtonProps['children']
+  /** Content for the secondary action button (typically cancel or dismiss) */
   secondaryButtonText?: DsButtonProps['children']
+  /** Custom React element to display as an illustration (icons, images, etc.) */
+  illustration?: React.ReactNode
 
+  /** Root container Paper customization */
   ContainerProps?: DsPaperProps
+  /** Kicker text Typography customization */
   KickerProps?: DsTypographyProps
+  /** Description text Typography customization */
   DescriptionProps?: DsTypographyProps
+  /** Header title DialogTitle customization */
   TitleProps?: DsDialogTitleProps
+  /** Close button IconButton customization */
   CloseIconButtonProps?: DsIconButtonProps
+  /** Close icon RemixIcon customization (ref omitted) */
   CloseIconProps?: Omit<DsRemixIconProps, 'ref'>
+  /** Illustration container DialogContent customization */
+  IllustrationProps?: DsDialogContentProps
+  /** Main content area DialogContent customization */
   ContentProps?: DsDialogContentProps
+  /** Action buttons container DialogActions customization */
   ActionsProps?: DsDialogActionsProps
+  /** Primary action Button customization (ref omitted) */
   primaryButtonProps?: Omit<DsButtonProps, 'ref'>
+  /** Secondary action Button customization (ref omitted) */
   secondaryButtonProps?: Omit<DsButtonProps, 'ref'>
 }
 


### PR DESCRIPTION
## 📝 Summary
DsBottomSheet added support for illustration

## 📌 Related Issue
NA

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [ ] Updated documentation/comments where needed
- [x] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [x] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:

1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/react-design-system -> dist

## 📸 Screenshots / Videos (if applicable)

DsBottomSheet added support for illustration
<img width="290" height="490" alt="Screenshot 2026-01-16 at 11 33 35 AM" src="https://github.com/user-attachments/assets/e76a0e33-3f46-4c47-bc98-385149817596" />


## 🧩 Notes
Any extra context, edge cases, or known limitations.