### PR TITLE
Updated Colors: Updated typoSecondary,typoTertiary and tertiary100

### DIFF
--- a/src/Constants/PALETTE.ts
+++ b/src/Constants/PALETTE.ts
@@ -23,7 +23,7 @@ export const PALETTE: DsPalette = {
   secondaryGrey20: '#F1F1F1',
   secondaryGrey10: '#F9F9F9',
 
-  tertiary100: '#12877F',
+  tertiary100: '#0C746C',
   tertiary80: '#49A49E',
   tertiary60: '#81C1BD',
   tertiary40: '#B8DDDB',

--- a/src/Theme/getColorScheme/light.ts
+++ b/src/Theme/getColorScheme/light.ts
@@ -83,8 +83,8 @@ export default function getLightModeColorScheme(colorPalette: DsPalette) {
     surfaceTertiary: secondaryGrey100,
 
     typoPrimary: primaryBlackLight,
-    typoSecondary: secondaryGrey80,
-    typoTertiary: secondaryGrey60,
+    typoSecondary: secondaryGrey90,
+    typoTertiary: secondaryGrey80,
     typoActionPrimary: primary,
     typoActionSecondary: secondary100,
     typoActionTertiary: tertiary100,


### PR DESCRIPTION
## 📝 Summary
Updated Colors: Updated typoSecondary,typoTertiary and tertiary100
Semantics Change:
```
CURRENT COLOR: sz/colour/typography/secondary - #6E6E6E (secondaryGrey80)
UPDATE: sz/colour/typography/secondary - #575757 (secondaryGrey90)

CURRENT COLOR: sz/colour/typography/tertiary - #9D9D9D (secondaryGrey60)
UPDATE: sz/colour/typography/tertiary - #6E6E6E (secondaryGrey80)

Primitives Change:
CURRENT COLOR: tertiary100 - #12877F
UPDATE: tertiary100 - #0C746C
```

## 📌 Related Issue
NA

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [ ] Updated documentation/comments where needed
- [x] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [x] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:

1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/rreact-design-system -> dist

## 📸 Screenshots / Videos (if applicable)

Before Change-
<img width="260" height="280" alt="Screenshot 2026-01-21 at 5 13 52 PM" src="https://github.com/user-attachments/assets/aec4954b-6725-4537-be0f-00cd6cc3c8df" />

After Change-


<img width="252" height="277" alt="Screenshot 2026-01-21 at 5 13 44 PM" src="https://github.com/user-attachments/assets/e44afd80-689f-4ea7-9e21-e4ee738d561c" />



## 🧩 Notes
Any extra context, edge cases, or known limitations.