### PR TITLE
Fixed Component: Icon weight in DsFab and DsButton fixed

### DIFF
--- a/src/Components/DsButton/DsButton.Overrides.ts
+++ b/src/Components/DsButton/DsButton.Overrides.ts
@@ -13,7 +13,7 @@ export const DsButtonOverrides = {
           cursor: 'not-allowed',
           pointerEvents: 'all'
         },
-        '.MuiButton-icon': {
+        '.MuiIcon-root': {
           fontWeight: 'var(--ds-typo-bodyRegularMedium-fontWeight)',
         },
         variants: [

--- a/src/Components/DsButton/DsButton.Overrides.ts
+++ b/src/Components/DsButton/DsButton.Overrides.ts
@@ -13,6 +13,9 @@ export const DsButtonOverrides = {
           cursor: 'not-allowed',
           pointerEvents: 'all'
         },
+        '.MuiButton-icon': {
+          fontWeight: 'var(--ds-typo-bodyRegularMedium-fontWeight)',
+        },
         variants: [
           {
             props: { variant: 'flushed' } as Partial<DsButtonProps>,

--- a/src/Components/DsFab/DsFab.Overrides.ts
+++ b/src/Components/DsFab/DsFab.Overrides.ts
@@ -18,6 +18,9 @@ export const DsFabOverrides = {
           fontSize: 'var(--ds-typo-bodyBoldMedium-fontSize)',
           lineHeight: 'var(--ds-typo-bodyBoldMedium-lineHeight)',
           letterSpacing: 'var(--ds-typo-bodyBoldMedium-letterSpacing)'
+        },
+        '.MuiIcon-root' : {
+          fontWeight: 'var(--ds-typo-bodyRegularMedium-fontWeight)',
         }
       } as CSSInterpolation,
       sizeLarge: {


### PR DESCRIPTION
## 📝 Summary
DsFab and DsButton top icon weight fixed

## 📌 Related Issue
NA

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [ ] Updated documentation/comments where needed
- [x] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [x] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:

1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/react-design-system -> dist

## 📸 Screenshots / Videos (if applicable)

DsFab icon weight changes
<img width="152" height="95" alt="Screenshot 2026-02-03 at 4 16 55 PM" src="https://github.com/user-attachments/assets/6d15a67c-3124-4bea-990f-ef2d5723564b" />

DsButton icon weight changes
<img width="202" height="79" alt="Screenshot 2026-02-03 at 4 26 49 PM" src="https://github.com/user-attachments/assets/aca38ad0-1699-4d2a-81ff-24f27e8ed073" />


## 🧩 Notes
Any extra context, edge cases, or known limitations.