### PR TITLE
Fixed Component: MuiSvgIcon replaced with MuiIcon class in MUI

### DIFF
--- a/src/Components/DsFab/DsFab.Overrides.ts
+++ b/src/Components/DsFab/DsFab.Overrides.ts
@@ -22,19 +22,19 @@ export const DsFabOverrides = {
       } as CSSInterpolation,
       sizeLarge: {
         padding: 'var(--ds-spacing-cool)',
-        '> .MuiSvgIcon-root': {
+        '> .MuiIcon-root': {
           fontSize: 'var(--ds-typo-fontSizePleasant)'
         }
       } as CSSInterpolation,
       sizeMedium: {
         padding: 'var(--ds-spacing-bitterCold)',
-        '> .MuiSvgIcon-root': {
+        '> .MuiIcon-root': {
           fontSize: 'var(--ds-typo-fontSizeMild)'
         }
       } as CSSInterpolation,
       sizeSmall: {
         padding: 'var(--ds-spacing-frostbite)',
-        '> .MuiSvgIcon-root': {
+        '> .MuiIcon-root': {
           fontSize: 'var(--ds-typo-fontSizeCool)'
         }
       } as CSSInterpolation,

--- a/src/Components/DsInputAdornment/DsInputAdornment.Overrides.ts
+++ b/src/Components/DsInputAdornment/DsInputAdornment.Overrides.ts
@@ -3,7 +3,7 @@ export const DsInputAdornmentOverrides = {
     styleOverrides: {
       root: {
         color: 'var(--ds-colour-iconDefault)',
-        '& .MuiSvgIcon-root': {
+        '& .MuiIcon-root': {
           cursor: 'pointer'
         }
       },

--- a/src/Components/DsToast/DsToast.Overrides.ts
+++ b/src/Components/DsToast/DsToast.Overrides.ts
@@ -32,7 +32,7 @@ export const DsToastOverrides = {
         '.MuiIconButton-root': {
           fontSize: 'var(--ds-typo-fontSizeMild)'
         },
-        '.MuiSvgIcon-root': {
+        '.MuiIcon-root': {
           fontSize: 'inherit'
         }
       },


### PR DESCRIPTION
## 📝 Summary
MuiSvgIcon replaced with MuiIcon class in MUI in below components-

- DsFab
- DsToast
- DsInputAdornment

## 📌 Related Issue
NA

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [ ] Updated documentation/comments where needed
- [x] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [x] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:

1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/rreact-design-system -> dist

## 📸 Screenshots / Videos (if applicable)

Icon css classes screenshot for DsFab

<img width="540" height="148" alt="Screenshot 2026-02-09 at 12 18 11 PM" src="https://github.com/user-attachments/assets/03930738-0897-4e8f-a855-78345c48e16f" />



## 🧩 Notes
Any extra context, edge cases, or known limitations.