### PR TITLE
Fixed Bug: DsFileUploader drop zone slot and undefined label bug fixed

### DIFF
--- a/src/Components/DsFileUploader/DsFileUploader.Component.tsx
+++ b/src/Components/DsFileUploader/DsFileUploader.Component.tsx
@@ -228,10 +228,10 @@ export const DsFileUploader = <
           InputProps={{
             accept: allowedFiles || accept,
             multiple: multiple,
+            ...slotProps?.DropZone?.InputProps,
             onChange: handleFileSelect,
             onDrop: handleDropFile,
             onDragOver: handleDragOverHandler,
-            ...slotProps?.DropZone?.InputProps
           }}
         />
       )}

--- a/src/Components/DsFileUploader/DsFileUploader.Component.tsx
+++ b/src/Components/DsFileUploader/DsFileUploader.Component.tsx
@@ -207,7 +207,7 @@ export const DsFileUploader = <
     ? Array.isArray(uploadedValue) && uploadedValue.length > 0
     : uploadedValue
 
-  const { SelectedItemSegment, UploadedItemSegment } = slots
+  const { SelectedItemSegment, UploadedItemSegment, DropZone } = slots
 
   return (
     <DsStack
@@ -222,18 +222,20 @@ export const DsFileUploader = <
         sx={{ mb: 'var(--ds-spacing-zero)', ...InputLabelProps?.sx }}
         {...InputLabelProps}
       />
-      <DsFileUploaderDropZone
-        variant={variant}
-        {...slotProps?.DropZone}
-        InputProps={{
-          accept: allowedFiles || accept,
-          multiple: multiple,
-          onChange: handleFileSelect,
-          onDrop: handleDropFile,
-          onDragOver: handleDragOverHandler,
-          ...slotProps?.DropZone?.InputProps
-        }}
-      />
+      {DropZone && (
+        <DropZone
+          variant={variant}
+          {...slotProps?.DropZone}
+          InputProps={{
+            accept: allowedFiles || accept,
+            multiple: multiple,
+            onChange: handleFileSelect,
+            onDrop: handleDropFile,
+            onDragOver: handleDragOverHandler,
+            ...slotProps?.DropZone?.InputProps
+          }}
+        />
+      )}
       {isSelectedSegmentVisible && SelectedItemSegment && (
         <SelectedItemSegment
           onPreview={handlePreviewFileAction}
@@ -263,5 +265,5 @@ export const DsFileUploader = <
         </UploadedItemSegment>
       )}
     </DsStack>
-  )
+  );
 }

--- a/src/Components/DsFileUploader/DsFileUploader.Component.tsx
+++ b/src/Components/DsFileUploader/DsFileUploader.Component.tsx
@@ -14,7 +14,6 @@ import type {
 import { DsFileUploaderDefaultProps } from './DsFileUploader.Types'
 import FileUploaderFiles from './FileUploaderFiles'
 import { getDefaultValue, getValidProcessedFile, mergeProps } from './helpers'
-import { DsFileUploaderDropZone } from './Slots/DsFileUploaderDropZone'
 import { DsStack } from '../DsStack'
 import { DsInputLabel } from '../DsInputLabel'
 

--- a/src/Components/DsFileUploader/DsFileUploader.Types.tsx
+++ b/src/Components/DsFileUploader/DsFileUploader.Types.tsx
@@ -1,4 +1,4 @@
-import type { ElementType, InputHTMLAttributes } from 'react'
+import type { ElementType } from 'react'
 import { DsInputLabelProps } from '../DsInputLabel'
 import { DsRemixIconProps } from '../DsRemixIcon'
 import { DsStackProps } from '../DsStack'

--- a/src/Components/DsFileUploader/DsFileUploader.Types.tsx
+++ b/src/Components/DsFileUploader/DsFileUploader.Types.tsx
@@ -1,4 +1,4 @@
-import type { ElementType } from 'react'
+import type { ElementType, InputHTMLAttributes } from 'react'
 import { DsInputLabelProps } from '../DsInputLabel'
 import { DsRemixIconProps } from '../DsRemixIcon'
 import { DsStackProps } from '../DsStack'
@@ -224,7 +224,10 @@ export interface IDsFileUploaderDropZoneProps extends DsStackProps {
   /**
    * To override props passed to input element
    */
-  InputProps?: DsInputProps['inputProps']
+  InputProps?: Omit<
+    NonNullable<DsInputProps['inputProps']>,
+    'onChange' | 'onDrop' | 'onDragOver'
+  >
   /**
    * This prop can be used to toggle the disabled state of the file uploaded.
    */

--- a/src/Components/DsFileUploader/Slots/DsFileUploaderSelectedFilesSegment.tsx
+++ b/src/Components/DsFileUploader/Slots/DsFileUploaderSelectedFilesSegment.tsx
@@ -25,14 +25,16 @@ export const DsFileUploaderSelectedFilesSegment = (
   const { label, children } = props
 
   return (
-    <DsStack spacing='var(--ds-spacing-frostbite)'>
-      <DsTypography
-        py='var(--ds-spacing-glacial)'
-        variant='subheadingSemiboldDefault'
-        color='var(--ds-colour-typoSecondary)'
-      >
-        {label}
-      </DsTypography>
+    <DsStack spacing="var(--ds-spacing-frostbite)">
+      {label && (
+        <DsTypography
+          py='var(--ds-spacing-glacial)'
+          variant='subheadingSemiboldDefault'
+          color='var(--ds-colour-typoSecondary)'
+        >
+          {label}
+        </DsTypography>
+      )}
       <DsStack
         spacing='var(--ds-spacing-frostbite)'
         sx={{ maxHeight: '440px', overflowY: 'auto' }}


### PR DESCRIPTION
## 📝 Summary
File uploader undefined label has issues regarding padding and height
File uploader dropzone button is directly imported, needs to imported from slots

## 📌 Related Issue
NA

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [ ] Updated documentation/comments where needed
- [x] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [x] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:

1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/rreact-design-system -> dist

## 📸 Screenshots / Videos (if applicable)
NA

## 🧩 Notes
Any extra context, edge cases, or known limitations.