### PR TITLE
Added feature: DsTabs added support for textFit and small size

### DIFF
--- a/src/Components/DsTab/DsTab.Overrides.ts
+++ b/src/Components/DsTab/DsTab.Overrides.ts
@@ -14,9 +14,6 @@ export const DsTabOverrides = {
         gap: 'var(--ds-spacing-glacial)',
         minHeight: '36px',
         textTransform: 'none',
-        borderBottomWidth: '1px',
-        borderBottomStyle: 'solid',
-        borderBottomColor: 'var(--ds-colour-stateDisabledSurface)',
         '> .MuiTab-iconWrapper': {
           fontSize: 'var(--ds-typo-fontSizeFrostbite)',
           margin: 'var(--ds-spacing-zero)'
@@ -31,3 +28,4 @@ export const DsTabOverrides = {
     }
   }
 }
+

--- a/src/Components/DsTabs/DsTabs.Overrides.ts
+++ b/src/Components/DsTabs/DsTabs.Overrides.ts
@@ -1,7 +1,5 @@
-import type { CSSObject } from "@mui/system";
-
-import type { DsTabsProps } from "./DsTabs.Types";
-import { DsTabsDefaultProps } from "./DsTabs.Types";
+import { CSSObject } from "@mui/system";
+import { DsTabsDefaultProps, DsTabsProps } from "./DsTabs.Types";
 
 export const DsTabsOverrides = {
   MuiTabs: {
@@ -9,40 +7,38 @@ export const DsTabsOverrides = {
     styleOverrides: {
       root: {
         minHeight: "36px",
+        borderBottom: "1px solid var(--ds-colour-strokeDefault)",
         variants: [
           {
             props: { "ds-variant": "container" } as Partial<DsTabsProps>,
             style: {
+              borderBottom: "none",
               "> .MuiTabs-scroller > .MuiTabs-indicator": {
                 height: "0px",
               },
               "> .MuiTabs-scroller > .MuiTabs-flexContainer": {
-                gap: "var(--ds-spacing-glacial)",
+                gap: "var(--ds-spacing-frostbite)",
                 "> .MuiTab-root": {
-                  fontWeight:
-                    "var(--ds-typo-supportRegularMetadata-fontWeight)",
-                  fontSize: "var(--ds-typo-supportRegularMetadata-fontSize)",
-                  lineHeight:
-                    "var(--ds-typo-supportRegularMetadata-lineHeight)",
+                  fontWeight: "var(--ds-typo-bodyRegularMedium-fontWeight)",
+                  fontSize: "var(--ds-typo-bodyRegularMedium-fontSize)",
+                  lineHeight: "var(--ds-typo-bodyRegularMedium-lineHeight)",
                   letterSpacing:
-                    "var(--ds-typo-supportRegularMetadata-letterSpacing)",
-                  borderRadius: "var(--ds-radius-quickFreeze)",
-                  paddingTop: "var(--ds-spacing-frostbite)",
-                  paddingBottom: "var(--ds-spacing-frostbite)",
-                  borderWidth: "1px",
-                  borderStyle: "solid",
+                    "var(--ds-typo-bodyRegularMedium-letterSpacing)",
+                  borderRadius: "var(--ds-radius-glacial)",
+                  padding:
+                    "var(--ds-spacing-glacial) var(--ds-spacing-frostbite)",
+                  border: "1px solid var(--ds-colour-strokeDefault)",
                   backgroundColor: "var(--ds-colour-surfaceSecondary)",
-                  borderColor: "var(--ds-colour-strokeDefault)",
                   color: "var(--ds-colour-typoSecondary)",
                   "&.Mui-selected": {
-                    backgroundColor:
-                      "var(--ds-colour-stateSelectedSecondaryHover)",
-                    borderColor: "var(--ds-colour-strokeSecondarySelected)",
+                    backgroundColor: "var(--ds-colour-neutral2)",
+                    borderColor: "var(--ds-colour-iconTypical)",
                     color: "var(--ds-colour-typoActionTertiary)",
+                    fontWeight: "var(--ds-typo-bodyBoldMedium-fontWeight)",
                   },
                   "&.Mui-disabled": {
-                    backgroundColor: "transparent",
-                    borderColor: "transparent",
+                    backgroundColor: "var(--ds-colour-stateDisabledSurface)",
+                    borderColor: "var(--ds-colour-strokeDisabled)",
                     color: "var(--ds-colour-typoDisabled)",
                   },
                 },
@@ -52,13 +48,13 @@ export const DsTabsOverrides = {
           {
             props: { "ds-variant": "segmented" } as Partial<DsTabsProps>,
             style: {
+              borderBottom: "none",
               "& .MuiTabs-scroller": {
                 backgroundColor: "var(--ds-colour-neutral1)",
                 borderRadius: "var(--ds-radius-glacial)",
                 padding: "var(--ds-spacing-quickFreeze)",
                 boxSizing: "border-box",
                 position: "relative",
-
                 "& .MuiTabs-indicator": {
                   height: "calc(100% - var(--ds-spacing-glacial))",
                   top: "var(--ds-spacing-quickFreeze)",
@@ -87,6 +83,56 @@ export const DsTabsOverrides = {
                     backgroundColor: "var(--ds-colour-neutral1)",
                     color: "var(--ds-colour-typoDisabled)",
                     fontWeight: "var(--ds-typo-bodyRegularMedium-fontWeight)",
+                  },
+                },
+              },
+            } as CSSObject,
+          },
+          {
+            props: (props: DsTabsProps) =>
+              props["ds-textfit"] === "fixed" &&
+              props["ds-variant"] !== "container" &&
+              props["ds-variant"] !== "segmented" &&
+              props.orientation !== "vertical",
+            style: {
+              "> .MuiTabs-scroller > .MuiTabs-flexContainer": {
+                borderBottom: "none",
+                "> .MuiTab-root": {
+                  minWidth: "unset",
+                  paddingRight: "0 !important",
+                  paddingLeft: "0 !important",
+                  marginRight: "var(--ds-spacing-bitterCold) !important",
+                  marginLeft: "var(--ds-spacing-bitterCold) !important",
+                },
+              },
+            } as CSSObject,
+          },
+          {
+            props: { orientation: "vertical" } as Partial<DsTabsProps>,
+            style: {
+              borderBottom: "none",
+              "> .MuiTabs-scroller > .MuiTabs-flexContainer": {
+                "> .MuiTab-root": {
+                  borderBottom: "1px solid var(--ds-colour-strokeDefault)",
+                },
+              } as CSSObject,
+            },
+          },
+          {
+            props: { "ds-size": "small" } as Partial<DsTabsProps>,
+            style: {
+              minHeight: "auto",
+              "> .MuiTabs-scroller > .MuiTabs-flexContainer": {
+                "> .MuiTab-root": {
+                  minHeight: "unset",
+                  fontWeight: "var(--ds-typo-bodyRegularSmall-fontWeight)",
+                  fontSize: "var(--ds-typo-bodyRegularSmall-fontSize)",
+                  lineHeight: "var(--ds-typo-bodyRegularSmall-lineHeight)",
+                  padding: "var(--ds-spacing-gelid) var(--ds-spacing-glacial)",
+                  letterSpacing:
+                    "var(--ds-typo-bodyRegularSmall-letterSpacing)",
+                  "&.Mui-selected": {
+                    fontWeight: "var(--ds-typo-bodyBoldSmall-fontWeight)",
                   },
                 },
               },

--- a/src/Components/DsTabs/DsTabs.Overrides.ts
+++ b/src/Components/DsTabs/DsTabs.Overrides.ts
@@ -96,7 +96,6 @@ export const DsTabsOverrides = {
               props.orientation !== "vertical",
             style: {
               "> .MuiTabs-scroller > .MuiTabs-flexContainer": {
-                borderBottom: "none",
                 "> .MuiTab-root": {
                   minWidth: "unset",
                   paddingRight: "0 !important",

--- a/src/Components/DsTabs/DsTabs.Overrides.ts
+++ b/src/Components/DsTabs/DsTabs.Overrides.ts
@@ -89,24 +89,6 @@ export const DsTabsOverrides = {
             } as CSSObject,
           },
           {
-            props: (props: DsTabsProps) =>
-              props["ds-textfit"] === "fixed" &&
-              props["ds-variant"] !== "container" &&
-              props["ds-variant"] !== "segmented" &&
-              props.orientation !== "vertical",
-            style: {
-              "> .MuiTabs-scroller > .MuiTabs-flexContainer": {
-                "> .MuiTab-root": {
-                  minWidth: "unset",
-                  paddingRight: "0 !important",
-                  paddingLeft: "0 !important",
-                  marginRight: "var(--ds-spacing-bitterCold) !important",
-                  marginLeft: "var(--ds-spacing-bitterCold) !important",
-                },
-              },
-            } as CSSObject,
-          },
-          {
             props: { orientation: "vertical" } as Partial<DsTabsProps>,
             style: {
               borderBottom: "none",
@@ -133,6 +115,23 @@ export const DsTabsOverrides = {
                   "&.Mui-selected": {
                     fontWeight: "var(--ds-typo-bodyBoldSmall-fontWeight)",
                   },
+                },
+              },
+            } as CSSObject,
+          },
+          {
+            props: (props: DsTabsProps) =>
+              props["ds-textfit"] === "fixed" &&
+              !props["ds-variant"] &&
+              props.orientation === "horizontal",
+            style: {
+              "> .MuiTabs-scroller > .MuiTabs-flexContainer": {
+                "> .MuiTab-root": {
+                  minWidth: "unset",
+                  paddingRight: "0",
+                  paddingLeft: "0",
+                  marginRight: "var(--ds-spacing-bitterCold)",
+                  marginLeft: "var(--ds-spacing-bitterCold)",
                 },
               },
             } as CSSObject,

--- a/src/Components/DsTabs/DsTabs.Types.ts
+++ b/src/Components/DsTabs/DsTabs.Types.ts
@@ -2,9 +2,13 @@ import { TabsProps } from "@mui/material";
 
 export interface DsTabsProps extends TabsProps {
   "ds-variant"?: "container" | "segmented";
+  "ds-size"?: "small" | "medium";
+  "ds-textfit"?: "fixed" | "filled";
 }
 
 export const DsTabsDefaultProps: DsTabsProps = {
   indicatorColor: "secondary",
   textColor: "secondary",
+  "ds-size": "medium",
+  "ds-textfit": "filled",
 };


### PR DESCRIPTION
## 📝 Summary
DsTabs added support for textFit and small size

## 📌 Related Issue
NA

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [ ] Updated documentation/comments where needed
- [x] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [x] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:

1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/rreact-design-system -> dist

## 📸 Screenshots / Videos (if applicable)
<img width="671" height="603" alt="Screenshot 2026-03-26 at 1 42 26 PM" src="https://github.com/user-attachments/assets/13f7d033-1af8-40cd-9f9d-70134ab4c8de" />





## 🧩 Notes
Any extra context, edge cases, or known limitations.