### PR TITLE
Updated component: DsBottomSheet close icon color updated

### DIFF
--- a/src/Components/DsBottomSheet/DsBottomSheet.Component.tsx
+++ b/src/Components/DsBottomSheet/DsBottomSheet.Component.tsx
@@ -106,7 +106,7 @@ export const DsBottomSheet: FC<DsBottomSheetProps> = (inProps) => {
             flexGrow: 0,
             alignSelf: 'center',
             backgroundColor: 'var(--ds-colour-iconDefault)',
-            color: 'var(--ds-colour-iconDisabled)',
+            color: 'var(--ds-colour-iconOnSurfaceDynamic)',
             borderRadius: '50%',
             p: 'var(--ds-spacing-glacial)',
             mb: 'var(--ds-spacing-bitterCold)',


### PR DESCRIPTION
## 📝 Summary
updated close icon of bottomsheet component to `var(--ds-colour-iconOnSurfaceDynamic)
`
## 📌 Related Issue
NA

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [ ] Updated documentation/comments where needed
- [ ] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [x] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:

1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/rreact-design-system -> dist

## 📸 Screenshots / Videos (if applicable)
<img width="292" height="498" alt="Screenshot 2026-04-01 at 3 21 07 PM" src="https://github.com/user-attachments/assets/7b069cbe-9718-435d-9919-a4f757ff6114" />


## 🧩 Notes
Any extra context, edge cases, or known limitations.