### PR TITLE
Fixed Colours: DsSearchbar search icon color changes to iconDefault t…

### DIFF
--- a/src/Components/DsSearchbar/DsSearchbar.Component.tsx
+++ b/src/Components/DsSearchbar/DsSearchbar.Component.tsx
@@ -25,7 +25,7 @@ export class DsSearchbar extends Component<
       <DsInputAdornment {...startAdornmentProps} position="start">
         <DsRemixIcon
           className="ri-search-line"
-          color="iconDisabled"
+          color="iconDefault"
           fontSize="cool"
         />
       </DsInputAdornment>


### PR DESCRIPTION
## 📝 Summary
DSSEARCHBAR COMPONENT SEARCH ICON COLOR CHANGED FROM ICONDISABLED TO ICONDEFAULT FOR ACCESSIBILITY CONCERNS

## 📌 Related Issue
https://jira.axisb.com/browse/SUB-1775

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [ ] Updated documentation/comments where needed
- [x] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [x] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:

1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/react-design-system -> dist

## 📸 Screenshots / Videos (if applicable)

before -
<img width="352" height="92" alt="Screenshot 2026-04-14 at 10 35 59 AM" src="https://github.com/user-attachments/assets/cd3977f4-6f7b-4d68-bc45-6ab0c52e8934" />


after - 
<img width="1115" height="140" alt="Screenshot 2026-04-14 at 10 35 19 AM" src="https://github.com/user-attachments/assets/25ebb77f-1bfc-4917-9226-c215e88a5c42" />




## 🧩 Notes
Any extra context, edge cases, or known limitations.