### PR TITLE
Fixed Styles: DsHeader mobile and desktop variant height fixed

### DIFF
--- a/src/Theme/rules.ts
+++ b/src/Theme/rules.ts
@@ -1,8 +1,8 @@
 import { DsRules } from '../Types/DsRules'
 
 const dsRules: DsRules = {
-  headerMobileHeight: '64px',
-  headerDesktopHeight: '84px',
+  headerMobileHeight: '44px',
+  headerDesktopHeight: '64px',
 
   appBarMobileMinHeight: '56px',
 


### PR DESCRIPTION
## 📝 Summary
Header component height is not correct for both mobile and desktop displays, we have fixed it here

## 📌 Related Issue
NA

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [ ] Updated documentation/comments where needed
- [x] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [x] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:

1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/react-design-system -> dist

## 📸 Screenshots / Videos (if applicable)




## 🧩 Notes
Any extra context, edge cases, or known limitations.