### PR TITLE
Fixed Component: DsDatePicker horizontal scroll in mobile dialog and month view height fixed

### DIFF
--- a/src/Theme/rules.ts
+++ b/src/Theme/rules.ts
@@ -27,7 +27,9 @@ const dsRules: DsRules = {
 
   buttonSmallLoaderWidth: '32px',
   buttonMediumLoaderWidth: '34px',
-  buttonLargeLoaderWidth: '42px'
+  buttonLargeLoaderWidth: '42px',
+
+  datePickerWidth: '328px',
 }
 
 export default dsRules

--- a/src/Types/DsRules.ts
+++ b/src/Types/DsRules.ts
@@ -19,5 +19,6 @@ export type DsRulesKeys =
   | 'buttonLargeLoaderWidth'
   | 'buttonMediumLoaderWidth'
   | 'buttonSmallLoaderWidth'
+  | 'datePickerWidth'
 
 export type DsRules = { [key in DsRulesKeys]: string }

--- a/src/x-datepicker/Components/DsDatePicker/DsDatePicker.Component.tsx
+++ b/src/x-datepicker/Components/DsDatePicker/DsDatePicker.Component.tsx
@@ -140,6 +140,10 @@ export const DsDatePicker: React.FC<DsDatePickerProps> = inProps => {
         }}
         slotProps={{
           ...props.slotProps,
+          mobilePaper: {
+            sx: { width: 'var(--ds-rules-datePickerWidth)' },
+            ...props.slotProps?.mobilePaper
+          },
           day: {
             // commented to show current day border highlight
             // disableHighlightToday: true,

--- a/src/x-datepicker/Components/DsDatePicker/DsDatePicker.Component.tsx
+++ b/src/x-datepicker/Components/DsDatePicker/DsDatePicker.Component.tsx
@@ -141,8 +141,11 @@ export const DsDatePicker: React.FC<DsDatePickerProps> = inProps => {
         slotProps={{
           ...props.slotProps,
           mobilePaper: {
-            sx: { width: 'var(--ds-rules-datePickerWidth)' },
-            ...props.slotProps?.mobilePaper
+            ...props.slotProps?.mobilePaper,
+            sx: {
+              width: 'var(--ds-rules-datePickerWidth)',
+              ...props.slotProps?.mobilePaper?.sx,
+            },
           },
           day: {
             // commented to show current day border highlight

--- a/src/x-datepicker/Components/DsDatePicker/DsDatePicker.Overrides.ts
+++ b/src/x-datepicker/Components/DsDatePicker/DsDatePicker.Overrides.ts
@@ -34,7 +34,7 @@ export const DsDatePickerOverrides = {
   MuiDateCalendar: {
     styleOverrides: {
       root: {
-        width: '328px',
+        width: 'var(--ds-rules-datePickerWidth)',
         maxHeight: '416px',
         height: '100%',
         paddingTop: 'var(--ds-spacing-glacial)'
@@ -118,6 +118,7 @@ export const DsDatePickerOverrides = {
         paddingRight: 'var(--ds-spacing-bitterCold)'
       },
       button: {
+        margin: 'var(--ds-spacing-glacial) var(--ds-spacing-zero)',
         fontWeight: 'var(--ds-typo-bodyRegularLarge-fontWeight)',
         fontSize: 'var(--ds-typo-bodyRegularLarge-fontSize)',
         lineHeight: 'var(--ds-typo-bodyRegularLarge-lineHeight)',


### PR DESCRIPTION
## 📝 Summary
DsDatePicker component had a horizontal scroll issue in the mobile dialog on small-width devices, and the month view height has been fixed.

## 📌 Related Issue
NA

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [ ] Updated documentation/comments where needed
- [x] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [x] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:

1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/react-design-system -> dist

## 📸 Screenshots / Videos (if applicable)




## 🧩 Notes
Any extra context, edge cases, or known limitations.