### PR TITLE
Added Component: DsPickersDay exported mui pickersday component

### DIFF
--- a/src/x-datepicker/Components/DsDatePicker/DsDatePicker.Overrides.ts
+++ b/src/x-datepicker/Components/DsDatePicker/DsDatePicker.Overrides.ts
@@ -75,39 +75,6 @@ export const DsDatePickerOverrides = {
       }
     }
   },
-  MuiPickersDay: {
-    styleOverrides: {
-      root: {
-        width: '36px',
-        height: '36px',
-        margin: 'var(--ds-spacing-zero)',
-        fontWeight: 'var(--ds-typo-bodyRegularMedium-fontWeight)',
-        fontSize: 'var(--ds-typo-bodyRegularMedium-fontSize)',
-        lineHeight: 'var(--ds-typo-bodyRegularMedium-lineHeight)',
-        letterSpacing: 'var(--ds-typo-bodyRegularMedium-letterSpacing)',
-        '&.Mui-selected': {
-          backgroundColor: 'var(--ds-colour-actionSecondary)',
-          color: 'var(--ds-colour-typoOnSurface)',
-          '&:hover': {
-            backgroundColor: 'var(--ds-colour-actionSecondary)',
-            color: 'var(--ds-colour-typoOnSurface)'
-          },
-          '&:focus': {
-            backgroundColor: 'var(--ds-colour-actionSecondary)',
-            color: 'var(--ds-colour-typoOnSurface)'
-          }
-        }
-      },
-      today: {
-        ':not(.Mui-selected)': {
-          background: 'transparent',
-          borderWidth: '1px',
-          borderStyle: 'solid',
-          borderColor: 'var(--ds-colour-actionSecondary)'
-        }
-      }
-    }
-  },
   MuiMonthCalendar: {
     styleOverrides: {
       root: {

--- a/src/x-datepicker/Components/DsDateRangePicker/DateRangePickerDay.tsx
+++ b/src/x-datepicker/Components/DsDateRangePicker/DateRangePickerDay.tsx
@@ -1,9 +1,9 @@
 import React, { useMemo } from "react";
-import { PickersDay } from "@mui/x-date-pickers";
 import { isSameDay, isWithinInterval } from "date-fns";
 
 import type { IDateRangePickerDayProps } from "./DsDateRangePicker.Types";
-import { DsBox } from "../../../Components";
+import { DsBox } from "../../../Components/DsBox";
+import { DsPickersDay } from "../../Components/DsPickersDay";
 
 /**
  * Custom day component for date range picker calendar
@@ -57,7 +57,7 @@ import { DsBox } from "../../../Components";
 
     return (
       <DsBox sx={boxStyles}>
-        <PickersDay
+        <DsPickersDay
           {...other}
           day={day}
           onClick={() => onDateClick(day, activeField)}

--- a/src/x-datepicker/Components/DsDateRangePicker/DsDateRangePicker.Component.tsx
+++ b/src/x-datepicker/Components/DsDateRangePicker/DsDateRangePicker.Component.tsx
@@ -16,9 +16,9 @@ import {
   validateDateRange,
 } from "./helpers";
 import type {
+  DsDateRangePickerProps,
   IDateRangePickerActionBarProps,
   IDateRangePickerTextFieldProps,
-  IDsDateRangePickerProps,
 } from "./DsDateRangePicker.Types";
 import { DsDateRangePickerDefaultProps } from "./DsDateRangePicker.Types";
 import {
@@ -47,7 +47,7 @@ import { DateRangePickerDay } from "./DateRangePickerDay";
 
 const DEFAULT_ACTIONS = ["clear", "accept"] as const;
 
-export const DsDateRangePicker = (InProps: IDsDateRangePickerProps) => {
+export const DsDateRangePicker = (InProps: DsDateRangePickerProps) => {
   const props = { ...DsDateRangePickerDefaultProps, ...InProps };
 
   const {

--- a/src/x-datepicker/Components/DsDateRangePicker/DsDateRangePicker.Types.ts
+++ b/src/x-datepicker/Components/DsDateRangePicker/DsDateRangePicker.Types.ts
@@ -145,7 +145,7 @@ export interface IDateFieldButtonProps {
   onClick: () => void;
 }
 
-export interface IDsDateRangePickerProps extends Omit<
+export interface DsDateRangePickerProps extends Omit<
   DsDatePickerProps,
   | "onChange"
   | "value"
@@ -172,7 +172,7 @@ export interface IDsDateRangePickerProps extends Omit<
   endDateLabelSupportText?: string;
 }
 
-export const DsDateRangePickerDefaultProps: Partial<IDsDateRangePickerProps> = {
+export const DsDateRangePickerDefaultProps: Partial<DsDateRangePickerProps> = {
   /**
    * Note: Component overrides are restricted to maintain design consistency.
    * Only label-related props in textFields can be customized by consumers.

--- a/src/x-datepicker/Components/DsPickersDay/DsPickersDay.Component.ts
+++ b/src/x-datepicker/Components/DsPickersDay/DsPickersDay.Component.ts
@@ -1,0 +1,1 @@
+export { PickersDay as DsPickersDay } from '@mui/x-date-pickers/PickersDay';

--- a/src/x-datepicker/Components/DsPickersDay/DsPickersDay.Overrides.ts
+++ b/src/x-datepicker/Components/DsPickersDay/DsPickersDay.Overrides.ts
@@ -1,1 +1,35 @@
-export const DsPickersDayOverrides = {}
+export const DsPickersDayOverrides = {
+  MuiPickersDay: {
+    styleOverrides: {
+      root: {
+        width: "36px",
+        height: "36px",
+        margin: "var(--ds-spacing-zero)",
+        fontWeight: "var(--ds-typo-bodyRegularMedium-fontWeight)",
+        fontSize: "var(--ds-typo-bodyRegularMedium-fontSize)",
+        lineHeight: "var(--ds-typo-bodyRegularMedium-lineHeight)",
+        letterSpacing: "var(--ds-typo-bodyRegularMedium-letterSpacing)",
+        "&.Mui-selected": {
+          backgroundColor: "var(--ds-colour-actionSecondary)",
+          color: "var(--ds-colour-typoOnSurface)",
+          "&:hover": {
+            backgroundColor: "var(--ds-colour-actionSecondary)",
+            color: "var(--ds-colour-typoOnSurface)",
+          },
+          "&:focus": {
+            backgroundColor: "var(--ds-colour-actionSecondary)",
+            color: "var(--ds-colour-typoOnSurface)",
+          },
+        },
+      },
+      today: {
+        ":not(.Mui-selected)": {
+          background: "transparent",
+          borderWidth: "1px",
+          borderStyle: "solid",
+          borderColor: "var(--ds-colour-actionSecondary)",
+        },
+      },
+    },
+  },
+};

--- a/src/x-datepicker/Components/DsPickersDay/DsPickersDay.Overrides.ts
+++ b/src/x-datepicker/Components/DsPickersDay/DsPickersDay.Overrides.ts
@@ -1,0 +1,1 @@
+export const DsPickersDayOverrides = {}

--- a/src/x-datepicker/Components/DsPickersDay/DsPickersDay.Types.ts
+++ b/src/x-datepicker/Components/DsPickersDay/DsPickersDay.Types.ts
@@ -1,0 +1,5 @@
+import type { PickersDayProps } from "@mui/x-date-pickers";
+
+export interface DsPickersDayProps extends PickersDayProps {}
+
+export const DsPickersDayDefaultProps = {};

--- a/src/x-datepicker/Components/DsPickersDay/index.ts
+++ b/src/x-datepicker/Components/DsPickersDay/index.ts
@@ -1,0 +1,3 @@
+export * from './DsPickersDay.Component'
+export * from './DsPickersDay.Types'
+export * from './DsPickersDay.Overrides'

--- a/src/x-datepicker/Components/index.ts
+++ b/src/x-datepicker/Components/index.ts
@@ -1,2 +1,3 @@
 export * from './DsDatePicker'
 export * from './DsDateRangePicker'
+export * from './DsPickersDay'

--- a/src/x-datepicker/componentOverrides.ts
+++ b/src/x-datepicker/componentOverrides.ts
@@ -1,8 +1,9 @@
-import { DsDatePickerOverrides, DsDateRangePickerOverrides } from './Components'
+import { DsDatePickerOverrides, DsDateRangePickerOverrides, DsPickersDayOverrides } from './Components'
 
 const XDatePickerComponentOverrides = {
   ...DsDatePickerOverrides,
   ...DsDateRangePickerOverrides,
+  ...DsPickersDayOverrides,
 }
 
 export default XDatePickerComponentOverrides


### PR DESCRIPTION
## 📝 Summary
exported MUI pickersday component as DsPickersDay 

## 📌 Related Issue
NA

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [ ] Updated documentation/comments where needed
- [ ] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [x] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:

1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/rreact-design-system -> dist

## 📸 Screenshots / Videos (if applicable)
Used pickersday as custom component in datepicker for custom styles -

<img width="342" height="484" alt="Screenshot 2026-04-01 at 1 35 46 PM" src="https://github.com/user-attachments/assets/84c977b3-5d2d-4fa9-91b5-55bc29aeba6e" />


## 🧩 Notes
Any extra context, edge cases, or known limitations.