### PR TITLE
Fixed Styles: DsDialog padding and shadow issues fixed 3.x

### DIFF
--- a/src/Components/DsDialog/DsDialog.Component.tsx
+++ b/src/Components/DsDialog/DsDialog.Component.tsx
@@ -114,7 +114,7 @@ export const DsDialog: React.FC<DsDialogProps> = inProps => {
               xs: 'var(--ds-spacing-bitterCold)',
               md: 'var(--ds-spacing-warm)'
             },
-            mb: 'var(--ds-spacing-quickFreeze)',
+            mb: 'var(--ds-spacing-glacial)',
             textTransform: 'uppercase',
             ...KickerProps?.sx
           }}
@@ -205,7 +205,7 @@ export const DsDialog: React.FC<DsDialogProps> = inProps => {
               ? undefined
               : {
                 xs: 'var(--ds-spacing-bitterCold)',
-                md: 'var(--ds-spacing-warm)'
+                md: 'var(--ds-spacing-mild)'
               },
             mt: 'var(--ds-spacing-glacial)',
             ...ActionsProps?.sx

--- a/src/Components/DsDialogActions/DsDialogActions.Overrides.ts
+++ b/src/Components/DsDialogActions/DsDialogActions.Overrides.ts
@@ -3,6 +3,7 @@ export const DsDialogActionsOverrides = {
     styleOverrides: {
       root: {
         boxShadow: 'var(--ds-elevation-1)',
+        clipPath: 'inset(-2px 0 0 0)', // show shadow only on top, clip right/bottom/left
         padding: 'var(--ds-spacing-zero)',
         '> *': {
           flex: 1

--- a/src/Components/DsDialogTitle/DsDialogTitle.Overrides.ts
+++ b/src/Components/DsDialogTitle/DsDialogTitle.Overrides.ts
@@ -10,7 +10,7 @@ export const DsDialogTitleOverrides = {
         letterSpacing: 'var(--ds-typo-headingBoldMedium-letterSpacing)',
         color: 'var(--ds-colour-typoPrimary)',
         padding: 'var(--ds-spacing-zero)',
-        marginBottom: 'var(--ds-spacing-quickFreeze)'
+        marginBottom: 'var(--ds-spacing-glacial)'
       } as CSSInterpolation
     }
   }


### PR DESCRIPTION
## 📝 Summary

- remove boxshadow from bottom
- gap between working area and button actions should be 24px not 32px
- the marginbottom between kicker n title should be 8px not 4px

## 📌 Related Issue
NA

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [ ] Updated documentation/comments where needed
- [ ] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [x] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:

1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/rreact-design-system -> dist

## 📸 Screenshots / Videos (if applicable)
<img width="630" height="498" alt="Screenshot 2026-06-25 at 2 21 45 PM" src="https://github.com/user-attachments/assets/eeb93e2c-f133-4477-96d3-e3a6b71d1195" />





## 🧩 Notes
Any extra context, edge cases, or known limitations.