### PR TITLE
Fixed Styles : DsBottomSheet gap fixed between title, kicker and description 2.x

### DIFF
--- a/src/Components/DsBottomSheet/DsBottomSheet.Component.tsx
+++ b/src/Components/DsBottomSheet/DsBottomSheet.Component.tsx
@@ -130,7 +130,7 @@ export const DsBottomSheet: FC<DsBottomSheetProps> = (inProps) => {
             {...KickerProps}
             sx={{
               px: 'var(--ds-spacing-bitterCold)',
-              mb: 'var(--ds-spacing-quickFreeze)',
+              mb: 'var(--ds-spacing-glacial)',
               textTransform: 'uppercase',
               ...KickerProps?.sx
             }}
@@ -159,7 +159,7 @@ export const DsBottomSheet: FC<DsBottomSheetProps> = (inProps) => {
             {...DescriptionProps}
             sx={{
               px: 'var(--ds-spacing-bitterCold)',
-              mt: 'var(--ds-spacing-quickFreeze)',
+              mt: 'var(--ds-spacing-glacial)',
               ...DescriptionProps?.sx
             }}
           >


### PR DESCRIPTION
## 📝 Summary

- the marginbottom between kicker n title should be 8px not 4px

## 📌 Related Issue
NA

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [ ] Updated documentation/comments where needed
- [ ] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [x] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:

1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/rreact-design-system -> dist

## 📸 Screenshots / Videos (if applicable)
<img width="290" height="383" alt="Screenshot 2026-06-26 at 4 49 54 PM" src="https://github.com/user-attachments/assets/285d0cda-9f88-43b2-b2ae-a2f8dea60e10" />






## 🧩 Notes
Any extra context, edge cases, or known limitations.