### PR TITLE
Added Feature: Dstooltip custom title prop added to add custom content

### DIFF
--- a/src/Components/DsTooltip/DsTooltip.Component.tsx
+++ b/src/Components/DsTooltip/DsTooltip.Component.tsx
@@ -14,7 +14,15 @@ export const CustomTooltip = <
   const { breakpoints } = useBreakPoints()
   const isMobile = breakpoints.xs || breakpoints.sm
   const renderTitle = () => {
-    const { heading, description } = props
+    const { heading, description, title } = props
+
+    if (title !== undefined) {
+      return title
+    }
+
+    if (!heading && !description) {
+      return null
+    }
 
     return (
       <>
@@ -39,14 +47,18 @@ export const CustomTooltip = <
     )
   }
 
-  const { slots, slotProps, children, ...tooltipProps } =
-    props
+  const { slots, slotProps, children, title, ...tooltipProps } = props
 
   const WrapperComponent = slots?.wrapper || React.Fragment
   const wrapperProps = slotProps?.wrapper || {}
 
   return (
-    <Tooltip slots={slots} slotProps={slotProps} title={renderTitle()} {...tooltipProps}>
+    <Tooltip
+      slots={slots}
+      slotProps={slotProps}
+      title={renderTitle()}
+      {...tooltipProps}
+    >
       <WrapperComponent {...wrapperProps}>{children || null}</WrapperComponent>
     </Tooltip>
   )

--- a/src/Components/DsTooltip/DsTooltip.Types.tsx
+++ b/src/Components/DsTooltip/DsTooltip.Types.tsx
@@ -22,6 +22,11 @@ export type DsTooltipProps<
   /** This prop can be used to provide a description to the tooltip */
   description?: string
   /**
+   * Custom content to render inside the tooltip.
+   * When provided, takes precedence over `heading` and `description`.
+   */
+  title?: TooltipProps['title']
+  /**
    * The components used for each slot inside.
    *
    * This prop is an alias for the `components` prop, which will be deprecated in the future.


### PR DESCRIPTION
## 📝 Summary
Added optional title prop to add custom content in the tooltip

## 📌 Related Issue
NA

## ✅ Checklist
- [x] Code compiles and passes lint checks
- [ ] Added/Updated tests if relevant
- [ ] Updated documentation/comments where needed
- [ ] No console warnings or errors
- [x] Mobile and responsive behavior verified
- [x] Cross-browser compatibility checked
- [x] All reviewers added and relevant labels applied

## 🧪 How to Test (Optional)
Steps to verify this PR manually:

1. clone RDS
2. build RDS
3. replace dist to your project's node_modules -> @am92/rreact-design-system -> dist

## 📸 Screenshots / Videos (if applicable)

<img width="362" height="282" alt="Screenshot 2026-07-10 at 1 05 20 PM" src="https://github.com/user-attachments/assets/25c1020c-ef81-48cb-8dea-683e6dbe15d5" />




## 🧩 Notes
Any extra context, edge cases, or known limitations.